### PR TITLE
Add DXT package distribution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,42 @@ Get started by integrating with your preferred AI development environment:
 - [Claude Code Integration](./docs/claude-code-integration.md) - Command-line development with Claude
 - [Claude Desktop Integration](./docs/claude-desktop-integration.md) - Desktop application integration
 
+## DXT Package Distribution
+
+This MCP server can be packaged as a DXT (Desktop Extension) file for easy distribution and installation. DXT is a standardized format for distributing local MCP servers, similar to browser extensions.
+
+### Creating the DXT Package
+
+To create a DXT package:
+
+```bash
+# Install the DXT CLI tool
+npm install -g @anthropic-ai/dxt
+
+# Build the server first
+npm run build
+
+# Create the DXT package
+npx @anthropic-ai/dxt pack
+```
+
+This will generate `mcp-devkit-server.dxt` using the configuration in `manifest.json`.
+
+### Installing the DXT Package
+
+Users can install the DXT package by:
+
+1. Opening the `.dxt` file with a compatible application (e.g., Claude Desktop)
+2. Following the installation prompts
+3. Providing their Mapbox access token when prompted
+
+The DXT package includes:
+
+- Pre-built server code (`dist/index.js`)
+- Server metadata and configuration
+- User configuration schema for the Mapbox access token
+- Automatic environment variable setup
+
 ## Getting Your Mapbox Access Token
 
 **A Mapbox access token is required to use this MCP server.**

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,37 @@
+{
+  "dxt_version": "0.1",
+  "name": "@mapbox/mcp-devkit-server",
+  "display_name": "Mapbox MCP Server",
+  "version": "0.2.1",
+  "description": "Mapbox MCP devkit server",
+  "author": {
+    "name": "Mapbox, Inc."
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/index.js"
+      ],
+      "env": {
+        "MAPBOX_ACCESS_TOKEN" : "${user_config.MAPBOX_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "user_config": {
+    "MAPBOX_ACCESS_TOKEN": {
+      "type": "string",
+      "title": "Mapbox access_token",
+      "description": "Enter your Mapbox secret access token to get started, if you don't have one, please register from https://account.mapbox.com/access-tokens/",
+      "required": true,
+      "sensitive": true
+    }
+  },
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mapbox/mcp-devkit-server.git"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-devkit-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mapbox MCP devkit server",
   "main": "dist/index.js",
   "module": "dist/index-esm.js",


### PR DESCRIPTION
## Summary
- Add DXT manifest configuration for desktop extension packaging
- Update README with DXT package creation and installation instructions  
- Include pre-built DXT package file for easy distribution
- Bump version to 0.2.2

## Test plan
- [x] Verify DXT package can be created using `npx @anthropic-ai/dxt pack`
- [x] Test installation of the generated .dxt file
- [x] Confirm Mapbox access token configuration works through DXT user config
- [x] Validate all documentation links and instructions are accurate