### PR TITLE
DXT package patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ npx @anthropic-ai/dxt pack
 
 This will generate `mcp-devkit-server.dxt` using the configuration in `manifest.json`.
 
-### Installing the DXT Package
-
-Users can install the DXT package by:
-
-1. Opening the `.dxt` file with a compatible application (e.g., Claude Desktop)
-2. Following the installation prompts
-3. Providing their Mapbox access token when prompted
-
 The DXT package includes:
 
 - Pre-built server code (`dist/index.js`)

--- a/docs/claude-desktop-integration.md
+++ b/docs/claude-desktop-integration.md
@@ -94,6 +94,24 @@ If you want to use a local version (need to clone and build from this repo):
 }
 ```
 
+## DXT Installation (Alternative)
+
+As an alternative to manual configuration, Claude Desktop users can install this MCP server using a pre-built DXT package:
+
+**⚠️ Important: Make sure you have the latest version of Claude Desktop installed. DXT support requires recent versions of Claude Desktop to function properly.**
+
+**[📦 Download DXT Package](https://github.com/mapbox/mcp-devkit-server/releases/latest/download/mcp-devkit-server.dxt)**
+
+### Installation Steps
+
+1. **Update Claude Desktop** - [Download the latest version](https://claude.ai/download) if you haven't recently
+2. Download the `.dxt` file from the link above
+3. Open the file with Claude Desktop
+4. Follow the installation prompts
+5. Provide your Mapbox access token when prompted
+
+This method automatically handles the configuration and setup, making it easier for users who prefer a one-click installation experience.
+
 ## Usage Examples
 
 Once configured, you can use natural language to interact with Mapbox development tools:

--- a/docs/claude-desktop-integration.md
+++ b/docs/claude-desktop-integration.md
@@ -36,11 +36,33 @@ See the [Token Requirements](#token-requirements) section below for detailed sco
 
 ### Configure Claude Desktop
 
+## Option 1: DXT Package Installation (Recommended)
+
+The easiest way to install this MCP server is using the pre-built DXT package:
+
+**⚠️ Important: Make sure you have the latest version of Claude Desktop installed. DXT support requires recent versions of Claude Desktop to function properly.**
+
+**[📦 Download DXT Package](https://github.com/mapbox/mcp-devkit-server/releases/latest/download/mcp-devkit-server.dxt)**
+
+### Installation Steps
+
+1. **Update Claude Desktop** - [Download the latest version](https://claude.ai/download) if you haven't recently
+2. Download the `.dxt` file from the link above
+3. Open the file with Claude Desktop
+4. Follow the installation prompts
+5. Provide your Mapbox access token when prompted
+
+This method automatically handles the configuration and setup, providing a one-click installation experience.
+
+## Option 2: Manual Configuration
+
+For users who prefer manual configuration or need custom setups, you can configure the server directly:
+
 1. Open Claude Desktop settings
 2. Navigate to the Model Context Protocol section
 3. Modify `claude_desktop_config.json` to add the new server:
 
-#### Option 1: NPM Package (Recommended)
+### NPM Package
 
 ```json
 {
@@ -56,7 +78,7 @@ See the [Token Requirements](#token-requirements) section below for detailed sco
 }
 ```
 
-#### Option 2: Docker Runtime
+### Docker Runtime
 
 ```json
 {
@@ -76,7 +98,7 @@ See the [Token Requirements](#token-requirements) section below for detailed sco
 }
 ```
 
-#### Option 3: Local Development
+### Local Development
 
 If you want to use a local version (need to clone and build from this repo):
 
@@ -94,23 +116,7 @@ If you want to use a local version (need to clone and build from this repo):
 }
 ```
 
-## DXT Installation (Alternative)
-
-As an alternative to manual configuration, Claude Desktop users can install this MCP server using a pre-built DXT package:
-
 **⚠️ Important: Make sure you have the latest version of Claude Desktop installed. DXT support requires recent versions of Claude Desktop to function properly.**
-
-**[📦 Download DXT Package](https://github.com/mapbox/mcp-devkit-server/releases/latest/download/mcp-devkit-server.dxt)**
-
-### Installation Steps
-
-1. **Update Claude Desktop** - [Download the latest version](https://claude.ai/download) if you haven't recently
-2. Download the `.dxt` file from the link above
-3. Open the file with Claude Desktop
-4. Follow the installation prompts
-5. Provide your Mapbox access token when prompted
-
-This method automatically handles the configuration and setup, making it easier for users who prefer a one-click installation experience.
 
 ## Usage Examples
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "dxt_version": "0.1",
   "name": "@mapbox/mcp-devkit-server",
-  "display_name": "Mapbox MCP Server",
-  "version": "0.2.1",
+  "display_name": "Mapbox MCP DevKit Server",
+  "version": "0.2.3",
   "description": "Mapbox MCP devkit server",
   "author": {
     "name": "Mapbox, Inc."
@@ -16,7 +16,7 @@
         "${__dirname}/dist/index.js"
       ],
       "env": {
-        "MAPBOX_ACCESS_TOKEN" : "${user_config.MAPBOX_ACCESS_TOKEN}"
+        "MAPBOX_ACCESS_TOKEN": "${user_config.MAPBOX_ACCESS_TOKEN}"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Mapbox MCP devkit server",
   "main": "dist/index.js",
   "module": "dist/index-esm.js",
@@ -17,10 +17,11 @@
     "format:fix": "prettier --write \"./src/**/*.{ts,tsx,js,json,md}\"",
     "prepare": "husky && node .husky/setup-hooks.js",
     "test": "jest",
-    "build": "npm run prepare && npm run build:esm && npm run build:cjs && npm run generate-version && node scripts/build-helpers.cjs copy-json && node scripts/add-shebang.cjs",
+    "build": "npm run prepare && npm run sync-manifest-version && npm run build:esm && npm run build:cjs && npm run generate-version && node scripts/build-helpers.cjs copy-json && node scripts/add-shebang.cjs",
     "build:esm": "node scripts/build-helpers.cjs esm-package && tsc -p tsconfig.json",
     "build:cjs": "node scripts/build-helpers.cjs cjs-package && tsc -p tsconfig.json",
     "generate-version": "node scripts/build-helpers.cjs generate-version",
+    "sync-manifest-version": "node scripts/build-helpers.cjs sync-manifest-version",
     "dev": "tsc -p tsconfig.json --watch"
   },
   "lint-staged": {

--- a/scripts/build-helpers.cjs
+++ b/scripts/build-helpers.cjs
@@ -42,6 +42,17 @@ function generateVersion() {
   fs.writeFileSync('dist/version.json', JSON.stringify(versionInfo, null, 2));
 }
 
+// Sync version from package.json to manifest.json
+function syncManifestVersion() {
+  const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const manifestJson = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+  
+  manifestJson.version = packageJson.version;
+  
+  fs.writeFileSync('manifest.json', JSON.stringify(manifestJson, null, 2) + '\n');
+  console.log(`Synced version ${packageJson.version} from package.json to manifest.json`);
+}
+
 // Copy JSON files to dist
 function copyJsonFiles() {
   const srcDir = 'src';
@@ -78,6 +89,9 @@ switch (command) {
     break;
   case 'generate-version':
     generateVersion();
+    break;
+  case 'sync-manifest-version':
+    syncManifestVersion();
     break;
   case 'copy-json':
     copyJsonFiles();


### PR DESCRIPTION
## Description

Since we already have a Mapbox MCP Server in another repository, rename the display_name in manifest.json to better indicate that this is the Mapbox MCP DevKit Server:

`  "display_name": "Mapbox MCP DevKit Server"`

Instead of having two identical "Mapbox MCP Server" we can now see the distinct DevKit server:

<img width="422" height="152" alt="image" src="https://github.com/user-attachments/assets/e5ee03b3-6fa0-43ed-b8f5-ef2677834fd5" />

Introduce a manifest.json version sync script so that package.json version is always in sync before creating DXT.

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
