### PR TITLE
Tilequery tool

### DIFF
--- a/src/tools/__snapshots__/tool-naming-convention.test.ts.snap
+++ b/src/tools/__snapshots__/tool-naming-convention.test.ts.snap
@@ -58,6 +58,11 @@ exports[`Tool Naming Convention should maintain consistent tool list (snapshot t
     "toolName": "retrieve_style_tool",
   },
   {
+    "className": "TilequeryTool",
+    "description": "Query vector and raster data from Mapbox tilesets at geographic coordinates",
+    "toolName": "tilequery_tool",
+  },
+  {
     "className": "UpdateStyleTool",
     "description": "Update an existing Mapbox style",
     "toolName": "update_style_tool",

--- a/src/tools/tilequery-tool/TilequeryTool.schema.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.schema.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const TilequerySchema = z.object({
+  tilesetId: z
+    .string()
+    .optional()
+    .default('mapbox.mapbox-streets-v8')
+    .describe('Tileset ID to query (default: mapbox.mapbox-streets-v8)'),
+  longitude: z
+    .number()
+    .min(-180)
+    .max(180)
+    .describe('Longitude coordinate to query'),
+  latitude: z
+    .number()
+    .min(-90)
+    .max(90)
+    .describe('Latitude coordinate to query'),
+  radius: z
+    .number()
+    .min(0)
+    .optional()
+    .default(0)
+    .describe('Radius in meters to search for features (default: 0)'),
+  limit: z
+    .number()
+    .min(1)
+    .max(50)
+    .optional()
+    .default(5)
+    .describe('Number of features to return (1-50, default: 5)'),
+  dedupe: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether to deduplicate identical features (default: true)'),
+  geometry: z
+    .enum(['polygon', 'linestring', 'point'])
+    .optional()
+    .describe('Filter results by geometry type'),
+  layers: z
+    .array(z.string())
+    .optional()
+    .describe('Specific layer names to query from the tileset'),
+  bands: z
+    .array(z.string())
+    .optional()
+    .describe('Specific band names to query (for rasterarray tilesets)')
+});
+
+export type TilequeryInput = z.infer<typeof TilequerySchema>;

--- a/src/tools/tilequery-tool/TilequeryTool.test.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.test.ts
@@ -1,0 +1,96 @@
+import { TilequeryTool } from './TilequeryTool.js';
+import { TilequeryInput } from './TilequeryTool.schema.js';
+
+describe('TilequeryTool', () => {
+  let tool: TilequeryTool;
+
+  beforeEach(() => {
+    tool = new TilequeryTool();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with correct name and description', () => {
+      expect(tool.name).toBe('tilequery_tool');
+      expect(tool.description).toBe(
+        'Query vector and raster data from Mapbox tilesets at geographic coordinates'
+      );
+    });
+  });
+
+  describe('schema validation', () => {
+    it('should validate minimal valid input', () => {
+      const input = {
+        longitude: -122.4194,
+        latitude: 37.7749
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tilesetId).toBe('mapbox.mapbox-streets-v8');
+        expect(result.data.radius).toBe(0);
+        expect(result.data.limit).toBe(5);
+        expect(result.data.dedupe).toBe(true);
+      }
+    });
+
+    it('should validate complete input with all optional parameters', () => {
+      const input: TilequeryInput = {
+        tilesetId: 'custom.tileset',
+        longitude: -122.4194,
+        latitude: 37.7749,
+        radius: 100,
+        limit: 10,
+        dedupe: false,
+        geometry: 'polygon',
+        layers: ['buildings', 'roads'],
+        bands: ['band1', 'band2']
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid longitude', () => {
+      const input = {
+        longitude: 181, // Invalid: > 180
+        latitude: 37.7749
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid latitude', () => {
+      const input = {
+        longitude: -122.4194,
+        latitude: 91 // Invalid: > 90
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject limit outside valid range', () => {
+      const input = {
+        longitude: -122.4194,
+        latitude: 37.7749,
+        limit: 51 // Invalid: > 50
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid geometry type', () => {
+      const input = {
+        longitude: -122.4194,
+        latitude: 37.7749,
+        geometry: 'invalid' as 'polygon'
+      };
+
+      const result = tool.inputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/tools/tilequery-tool/TilequeryTool.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.ts
@@ -1,0 +1,60 @@
+import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
+import { TilequerySchema, TilequeryInput } from './TilequeryTool.schema.js';
+
+export class TilequeryTool extends MapboxApiBasedTool<typeof TilequerySchema> {
+  name = 'tilequery_tool';
+  description =
+    'Query vector and raster data from Mapbox tilesets at geographic coordinates';
+
+  constructor() {
+    super({ inputSchema: TilequerySchema });
+  }
+
+  protected async execute(
+    input: TilequeryInput,
+    accessToken?: string
+  ): Promise<any> {
+    const { tilesetId, longitude, latitude, ...queryParams } = input;
+    const url = new URL(
+      `${MapboxApiBasedTool.MAPBOX_API_ENDPOINT}v4/${tilesetId}/tilequery/${longitude},${latitude}.json`
+    );
+
+    if (queryParams.radius !== undefined) {
+      url.searchParams.set('radius', queryParams.radius.toString());
+    }
+
+    if (queryParams.limit !== undefined) {
+      url.searchParams.set('limit', queryParams.limit.toString());
+    }
+
+    if (queryParams.dedupe !== undefined) {
+      url.searchParams.set('dedupe', queryParams.dedupe.toString());
+    }
+
+    if (queryParams.geometry) {
+      url.searchParams.set('geometry', queryParams.geometry);
+    }
+
+    if (queryParams.layers && queryParams.layers.length > 0) {
+      url.searchParams.set('layers', queryParams.layers.join(','));
+    }
+
+    if (queryParams.bands && queryParams.bands.length > 0) {
+      url.searchParams.set('bands', queryParams.bands.join(','));
+    }
+
+    url.searchParams.set('access_token', accessToken || '');
+
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Tilequery request failed: ${response.status} ${response.statusText}. ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+    return data;
+  }
+}

--- a/src/tools/toolRegistry.ts
+++ b/src/tools/toolRegistry.ts
@@ -9,6 +9,7 @@ import { ListStylesTool } from './list-styles-tool/ListStylesTool.js';
 import { ListTokensTool } from './list-tokens-tool/ListTokensTool.js';
 import { PreviewStyleTool } from './preview-style-tool/PreviewStyleTool.js';
 import { RetrieveStyleTool } from './retrieve-style-tool/RetrieveStyleTool.js';
+import { TilequeryTool } from './tilequery-tool/TilequeryTool.js';
 import { UpdateStyleTool } from './update-style-tool/UpdateStyleTool.js';
 
 // Central registry of all tools
@@ -24,7 +25,8 @@ export const ALL_TOOLS = [
   new ListTokensTool(),
   new BoundingBoxTool(),
   new CountryBoundingBoxTool(),
-  new CoordinateConversionTool()
+  new CoordinateConversionTool(),
+  new TilequeryTool()
 ] as const;
 
 export type ToolInstance = (typeof ALL_TOOLS)[number];


### PR DESCRIPTION
## Description

This PR adds support for the Mapbox Tilequery API as a new tool in the MCP devkit server. The tool allows users to query vector and raster data from Mapbox tilesets at specific geographic coordinates.

  ## What's Added
  - **New Tool**: `tilequery_tool` - Query vector and raster data from Mapbox tilesets at geographic coordinates
  - **Default Tileset**: Uses `mapbox.mapbox-streets-v8` as the default tileset when none is specified
  - **Complete API Support**: Implements all Mapbox Tilequery API parameters and options

  ## Features

  ### Required Parameters
  - `longitude` (-180 to 180)
  - `latitude` (-90 to 90)

  ### Optional Parameters with Defaults
  - `tilesetId` (default: `mapbox.mapbox-streets-v8`)
  - `radius` (default: 0 meters)
  - `limit` (default: 5, range: 1-50)
  - `dedupe` (default: true)

  ### Optional Filters
  - `geometry` - Filter by geometry type (polygon, linestring, point)
  - `layers` - Specific layer names to query
  - `bands` - Specific band names for rasterarray tilesets

  ## Usage Examples

  ### Basic query (uses defaults)
  ```json
  {
    "longitude": -122.4194,
    "latitude": 37.7749
  }
```
  ### Advanced query with custom parameters
```
  {
    "tilesetId": "mapbox.mapbox-streets-v8",
    "longitude": -122.4194,
    "latitude": 37.7749,
    "radius": 100,
    "limit": 10,
    "geometry": "polygon",
    "layers": ["contour"]
  }
```
  ### Implementation Details

  - Extends MapboxApiBasedTool for consistent authentication and error handling
  - Comprehensive Zod schema validation with proper TypeScript types
  - Full test coverage with 7 test cases covering all validation scenarios
  - Follows existing codebase patterns and conventions

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->
- Added unit tests
- Manual testing on Claude Desktop:
  - Simple query with just coordinates

<img width="1522" height="1200" alt="image" src="https://github.com/user-attachments/assets/b9cd168a-c422-4c23-9c1c-2e49ba49525a" />

- Ran a prompt which tested all the combinations of input parameters

<img width="710" height="589" alt="image" src="https://github.com/user-attachments/assets/847383ca-9be7-42a5-b1b1-02c0d481c5cd" />

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
