### PR TITLE
Improve style preview

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "@mapbox/mcp-devkit-server",
   "display_name": "Mapbox MCP DevKit Server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Mapbox MCP devkit server",
   "author": {
     "name": "Mapbox, Inc."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-devkit-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Mapbox MCP devkit server",
   "main": "dist/index.js",
   "module": "dist/index-esm.js",

--- a/src/tools/__snapshots__/tool-naming-convention.test.ts.snap
+++ b/src/tools/__snapshots__/tool-naming-convention.test.ts.snap
@@ -39,7 +39,7 @@ exports[`Tool Naming Convention should maintain consistent tool list (snapshot t
   },
   {
     "className": "ListStylesTool",
-    "description": "List all styles for a Mapbox account",
+    "description": "List styles for a Mapbox account. Use limit parameter to avoid large responses (recommended: limit=5-10). Use start parameter for pagination.",
     "toolName": "list_styles_tool",
   },
   {

--- a/src/tools/list-styles-tool/ListStylesTool.schema.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.schema.ts
@@ -4,8 +4,15 @@ export const ListStylesSchema = z.object({
   limit: z
     .number()
     .optional()
-    .describe('Maximum number of styles to return (default: no limit)'),
-  start: z.string().optional().describe('Start token for pagination')
+    .describe(
+      'Maximum number of styles to return (recommended: 10-50 to avoid token limits, default: no limit)'
+    ),
+  start: z
+    .string()
+    .optional()
+    .describe(
+      'Start token for pagination (use the "start" value from previous response)'
+    )
 });
 
 export type ListStylesInput = z.infer<typeof ListStylesSchema>;

--- a/src/tools/list-styles-tool/ListStylesTool.schema.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.schema.ts
@@ -5,7 +5,7 @@ export const ListStylesSchema = z.object({
     .number()
     .optional()
     .describe(
-      'Maximum number of styles to return (recommended: 10-50 to avoid token limits, default: no limit)'
+      'Maximum number of styles to return (recommended: 5-10 to avoid token limits, default: no limit)'
     ),
   start: z
     .string()

--- a/src/tools/list-styles-tool/ListStylesTool.test.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.test.ts
@@ -1,6 +1,6 @@
 // Use a token with valid JWT format for tests
 process.env.MAPBOX_ACCESS_TOKEN =
-  'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+  'sk.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
 import {
   setupFetch,

--- a/src/tools/list-styles-tool/ListStylesTool.test.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.test.ts
@@ -17,7 +17,9 @@ describe('ListStylesTool', () => {
     it('should have correct name and description', () => {
       const tool = new ListStylesTool();
       expect(tool.name).toBe('list_styles_tool');
-      expect(tool.description).toBe('List all styles for a Mapbox account');
+      expect(tool.description).toBe(
+        'List styles for a Mapbox account. Use limit parameter to avoid large responses (recommended: limit=5-10). Use start parameter for pagination.'
+      );
     });
 
     it('should have correct input schema', () => {

--- a/src/tools/list-styles-tool/ListStylesTool.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.ts
@@ -5,7 +5,8 @@ export class ListStylesTool extends MapboxApiBasedTool<
   typeof ListStylesSchema
 > {
   name = 'list_styles_tool';
-  description = 'List all styles for a Mapbox account';
+  description =
+    'List styles for a Mapbox account. Use limit parameter to avoid large responses (recommended: limit=5-10). Use start parameter for pagination.';
 
   constructor() {
     super({ inputSchema: ListStylesSchema });

--- a/src/tools/preview-style-tool/PreviewStyleTool.schema.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.schema.ts
@@ -4,6 +4,10 @@ export const PreviewStyleSchema = z.object({
   styleId: z.string().describe('Style ID to preview'),
   accessToken: z
     .string()
+    .startsWith(
+      'pk.',
+      'Invalid access token. Only public tokens (starting with pk.*) are allowed for preview URLs. Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs.'
+    )
     .describe(
       'Mapbox public access token (required, must start with pk.* and have styles:read permission). Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs. Please use an existing public token or get one from list_tokens_tool or create one with create_token_tool with styles:read permission.'
     ),

--- a/src/tools/preview-style-tool/PreviewStyleTool.schema.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.schema.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 
 export const PreviewStyleSchema = z.object({
   styleId: z.string().describe('Style ID to preview'),
+  accessToken: z
+    .string()
+    .describe(
+      'Mapbox public access token (required, must start with pk.* and have styles:read permission). Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs. Please use an existing public token or get one from list_tokens_tool or create one with create_token_tool with styles:read permission.'
+    ),
   title: z
     .boolean()
     .optional()

--- a/src/tools/preview-style-tool/PreviewStyleTool.test.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.test.ts
@@ -2,31 +2,11 @@
 process.env.MAPBOX_ACCESS_TOKEN =
   'sk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
-import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
 import { PreviewStyleTool } from './PreviewStyleTool.js';
 
 describe('PreviewStyleTool', () => {
   const TEST_ACCESS_TOKEN =
-    'pk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
-
-  beforeEach(() => {
-    // Mock getUserNameFromToken to handle pk. prefixed tokens
-    jest
-      .spyOn(MapboxApiBasedTool, 'getUserNameFromToken')
-      .mockImplementation((token) => {
-        // If token starts with pk., we expect it to be a prefixed token
-        if (token && token.startsWith('pk.')) {
-          // For test token, return 'test-user'
-          return 'test-user';
-        }
-        // For non-prefixed tokens, return 'test-user' as well
-        return 'test-user';
-      });
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+    'pk.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
   describe('tool metadata', () => {
     it('should have correct name and description', () => {

--- a/src/tools/preview-style-tool/PreviewStyleTool.test.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.test.ts
@@ -1,14 +1,32 @@
 // Use a token with valid JWT format for tests
 process.env.MAPBOX_ACCESS_TOKEN =
-  'pk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+  'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
+import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
 import { PreviewStyleTool } from './PreviewStyleTool.js';
 
 describe('PreviewStyleTool', () => {
   const TEST_ACCESS_TOKEN =
     'pk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
-  // No setup needed since we use user-provided tokens directly
+  beforeEach(() => {
+    // Mock getUserNameFromToken to handle pk. prefixed tokens
+    jest
+      .spyOn(MapboxApiBasedTool, 'getUserNameFromToken')
+      .mockImplementation((token) => {
+        // If token starts with pk., we expect it to be a prefixed token
+        if (token && token.startsWith('pk.')) {
+          // For test token, return 'test-user'
+          return 'test-user';
+        }
+        // For non-prefixed tokens, return 'test-user' as well
+        return 'test-user';
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   describe('tool metadata', () => {
     it('should have correct name and description', () => {

--- a/src/tools/preview-style-tool/PreviewStyleTool.test.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.test.ts
@@ -1,6 +1,6 @@
 // Use a token with valid JWT format for tests
 process.env.MAPBOX_ACCESS_TOKEN =
-  'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+  'sk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
 
 import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
 import { PreviewStyleTool } from './PreviewStyleTool.js';

--- a/src/tools/preview-style-tool/PreviewStyleTool.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.ts
@@ -1,13 +1,11 @@
+import { BaseTool } from '../BaseTool.js';
 import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
-import { ListTokensTool } from '../list-tokens-tool/ListTokensTool.js';
 import {
   PreviewStyleSchema,
   PreviewStyleInput
 } from './PreviewStyleTool.schema.js';
 
-export class PreviewStyleTool extends MapboxApiBasedTool<
-  typeof PreviewStyleSchema
-> {
+export class PreviewStyleTool extends BaseTool<typeof PreviewStyleSchema> {
   readonly name = 'preview_style_tool';
   readonly description =
     'Generate preview URL for a Mapbox style using an existing public token';
@@ -17,37 +15,19 @@ export class PreviewStyleTool extends MapboxApiBasedTool<
   }
 
   protected async execute(
-    input: PreviewStyleInput,
-    accessToken?: string
+    input: PreviewStyleInput
   ): Promise<{ type: 'text'; text: string }> {
-    const username = MapboxApiBasedTool.getUserNameFromToken(accessToken);
-
-    // Get list of tokens to find a public token
-    const listTokensTool = new ListTokensTool();
-    const tokensResult = await listTokensTool.run({
-      usage: 'pk' // Filter for public tokens only
-    });
-
-    if (tokensResult.isError) {
-      throw new Error('Failed to retrieve public tokens');
-    }
-
-    // Extract tokens from the response
-    const firstContent = tokensResult.content[0];
-    if (firstContent.type !== 'text') {
-      throw new Error('Unexpected response format from list tokens');
-    }
-    const tokensData = JSON.parse(firstContent.text);
-    const publicTokens = tokensData.tokens;
-
-    if (!publicTokens || publicTokens.length === 0) {
+    // Validate that the provided token is a public token
+    if (!input.accessToken.startsWith('pk.')) {
       throw new Error(
-        'No public tokens found. Please create a public token first.'
+        'Invalid access token. Only public tokens (starting with pk.*) are allowed for preview URLs. Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs.'
       );
     }
 
-    // Use the first available public token
-    const publicToken = publicTokens[0].token;
+    const username = MapboxApiBasedTool.getUserNameFromToken(input.accessToken);
+
+    // Use the user-provided public token
+    const publicToken = input.accessToken;
 
     // Build URL for the embeddable HTML endpoint
     const params = new URLSearchParams();

--- a/src/tools/preview-style-tool/PreviewStyleTool.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.ts
@@ -17,13 +17,6 @@ export class PreviewStyleTool extends BaseTool<typeof PreviewStyleSchema> {
   protected async execute(
     input: PreviewStyleInput
   ): Promise<{ type: 'text'; text: string }> {
-    // Validate that the provided token is a public token
-    if (!input.accessToken.startsWith('pk.')) {
-      throw new Error(
-        'Invalid access token. Only public tokens (starting with pk.*) are allowed for preview URLs. Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs.'
-      );
-    }
-
     const username = MapboxApiBasedTool.getUserNameFromToken(input.accessToken);
 
     // Use the user-provided public token

--- a/src/tools/style-comparison-tool/StyleComparisonTool.schema.ts
+++ b/src/tools/style-comparison-tool/StyleComparisonTool.schema.ts
@@ -13,6 +13,10 @@ export const StyleComparisonSchema = z.object({
     ),
   accessToken: z
     .string()
+    .startsWith(
+      'pk.',
+      'Invalid token type. Style comparison requires a public token (pk.*) that can be used in browser URLs. Secret tokens (sk.*) cannot be exposed in client-side applications. Please provide a public token with styles:read permission.'
+    )
     .describe(
       'Mapbox public access token (required, must start with pk.* and have styles:read permission). Secret tokens (sk.*) cannot be used as they cannot be exposed in browser URLs. Please use a public token or create one with styles:read permission.'
     ),

--- a/src/tools/style-comparison-tool/StyleComparisonTool.ts
+++ b/src/tools/style-comparison-tool/StyleComparisonTool.ts
@@ -17,19 +17,6 @@ export class StyleComparisonTool extends BaseTool<
   }
 
   /**
-   * Validates that the token is a public token
-   */
-  private validatePublicToken(token: string): void {
-    if (!token.startsWith('pk.')) {
-      throw new Error(
-        `Invalid token type. Style comparison requires a public token (pk.*) that can be used in browser URLs. ` +
-          `Secret tokens (sk.*) cannot be exposed in client-side applications. ` +
-          `Please provide a public token with styles:read permission.`
-      );
-    }
-  }
-
-  /**
    * Processes style input to extract username/styleId format
    */
   private processStyleId(style: string, accessToken: string): string {
@@ -61,9 +48,6 @@ export class StyleComparisonTool extends BaseTool<
   protected async execute(
     input: StyleComparisonInput
   ): Promise<{ type: 'text'; text: string }> {
-    // Validate that we have a public token
-    this.validatePublicToken(input.accessToken);
-
     // Process style IDs to get username/styleId format
     const beforeStyleId = this.processStyleId(input.before, input.accessToken);
     const afterStyleId = this.processStyleId(input.after, input.accessToken);


### PR DESCRIPTION
This pull request updates the `ListStylesTool` and `PreviewStyleTool` to improve clarity and security around token usage, especially for previewing Mapbox styles. The main changes clarify input requirements, enforce public token usage, and update related tests and documentation.

### Tool input and schema improvements

* Updated the description for `ListStylesTool` and its schema to recommend using the `limit` parameter (5-10) and clarify the use of the `start` parameter for pagination, improving guidance for API consumers. [[1]](diffhunk://#diff-1048277a0a9e7d930a40ed96bdb2223f84c9a2bc97d1d8f96af4e6335cd9ff40L42-R42) [[2]](diffhunk://#diff-0698d1f04e61d35dfc9cc42840aa65b0e7692f2855d2c669197086b1971d36c0L7-R15) [[3]](diffhunk://#diff-5716cb5e133a8b76b4503fff64d3257128dfc827b0a664f069bc451336c30debL20-R22) [[4]](diffhunk://#diff-d6b24c862c824ac29e8d7f9606399fcc87001c1b329ff74640893dbda75e03caL8-R9)
* Enhanced the `PreviewStyleTool` schema to require a public access token (`pk.*`) and provide clear instructions about token requirements and permissions.

### PreviewStyleTool logic and security

* Refactored `PreviewStyleTool` to accept a user-provided public token directly, removing the dependency on listing tokens internally. The tool now rejects secret (`sk.*`) and temporary (`tk.*`) tokens, ensuring only public tokens are used for preview URLs. [[1]](diffhunk://#diff-26c2fdd40b59acffef62dde20ec585daffa2c501af98f7797ccf1714d596a4aaR1-R8) [[2]](diffhunk://#diff-26c2fdd40b59acffef62dde20ec585daffa2c501af98f7797ccf1714d596a4aaL20-R30)

### Test updates

* Updated tests for both tools to use appropriate token formats and verify correct handling of public, secret, and temporary tokens, including error cases and parameter propagation. [[1]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105L3-R23) [[2]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105L57-R50) [[3]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105L67-R64) [[4]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105R76) [[5]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105R89) [[6]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105L111-R102) [[7]](diffhunk://#diff-e5f72274b9fcf8d4d88b2f772926742cd3b943352300808652ec196053eae105L120-R146) [[8]](diffhunk://#diff-5716cb5e133a8b76b4503fff64d3257128dfc827b0a664f069bc451336c30debL3-R3)

### Package metadata

* Bumped the package version from `0.3.0` to `0.3.1` in both `manifest.json` and `package.json` to reflect these changes. [[1]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R5) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)