### PR TITLE
[core] Add agents related documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,69 @@
+# GitHub Copilot Repository Instructions
+
+These instructions help GitHub Copilot and Copilot Chat provide better code suggestions and answers for the Mapbox MCP DevKit Server. For more details, see the [Copilot repository instructions guide](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions).
+
+---
+
+## Project Overview
+
+- Model Context Protocol (MCP) server for Mapbox developer APIs
+- Written in TypeScript (strict mode)
+- Provides tools for Mapbox style management, token management, GeoJSON processing, and more
+
+## Code Style
+
+- Use TypeScript strict mode
+- Prefer ES module syntax (`import`/`export`)
+- Destructure imports when possible
+- Tool names must be `snake_case_tool`
+- Tool schemas live in `*.schema.ts` files
+- Use Zod for schema validation
+- Run Prettier and ESLint before committing
+
+## Development & Build
+
+- Requires Node.js 22+
+- Install dependencies: `npm install`
+- Build: `npm run build`
+- Run tests: `npm test`
+- Lint: `npm run lint`
+- Format: `npm run format`
+- Create new tool: `npx plop create-tool`
+- Create DXT package: `npx @anthropic-ai/dxt pack`
+- Build Docker image: `docker build -t mapbox-mcp-devkit .`
+
+## Testing
+
+- Run all tests: `npm test`
+- Update tool snapshot tests after adding/removing tools:
+  - `npm test -- src/tools/tool-naming-convention.test.ts --updateSnapshot`
+- Run a single test file: `npm test -- path/to/testfile.ts`
+- Only update snapshots when changes are intentional
+
+## PR & Branching
+
+- Always run `npm run lint` and `npm test` before committing
+- Keep PRs focused and well-described
+
+## Tool Configuration
+
+- Tools can be enabled/disabled at startup (see `TOOL_CONFIGURATION.md`)
+- Example: `node dist/esm/index.js --enable-tools list_styles_tool,create_style_tool`
+
+## Security & Tokens
+
+- Each tool requires specific Mapbox token scopes (see `README.md`)
+- Using insufficient scopes will result in errors
+- Use `VERBOSE_ERRORS=true` for detailed error output
+
+## Additional Resources
+
+- [README.md](../README.md)
+- [AGENTS.md](../AGENTS.md)
+- [CLAUDE.md](../CLAUDE.md)
+- [TOOL_CONFIGURATION.md](../TOOL_CONFIGURATION.md)
+- [docs/claude-code-integration.md](../docs/claude-code-integration.md)
+
+---
+
+_Edit this file to keep Copilot up to date on project standards, commands, and best practices._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — Mapbox MCP DevKit Server
+
+This file provides coding agents with the context, commands, and conventions needed to work effectively with the Mapbox MCP DevKit Server. For human-focused docs, see `README.md`.
+
+---
+
+## Project Overview
+
+- Model Context Protocol (MCP) server for Mapbox developer APIs
+- Exposes tools for style management, token management, GeoJSON processing, and more
+- Written in TypeScript, strict mode enabled
+
+## Setup Commands
+
+- Install dependencies: `npm install`
+- Build the project: `npm run build`
+- Run tests: `npm test`
+- Lint code: `npm run lint`
+- Format code: `npm run format`
+- Create a new tool: `npx plop create-tool`
+- Create DXT package: `npx @anthropic-ai/dxt pack`
+- Build Docker image: `docker build -t mapbox-mcp-devkit .`
+
+## Environment
+
+- Requires Node.js 22+
+- Set `MAPBOX_ACCESS_TOKEN` in your environment (see `manifest.json`)
+- For Claude Code integration, see `docs/claude-code-integration.md`
+
+## Code Style
+
+- TypeScript strict mode
+- Use ES module syntax (`import`/`export`)
+- Destructure imports when possible
+- Tool names must be `snake_case_tool`
+- Tool schemas live in `*.schema.ts` files
+- Use Zod for schema validation
+- Run Prettier and ESLint before committing
+
+## Testing Instructions
+
+- Run all tests: `npm test`
+- Update tool snapshot tests after adding/removing tools:
+  - `npm test -- src/tools/tool-naming-convention.test.ts --updateSnapshot`
+- Run a single test file: `npm test -- path/to/testfile.ts`
+- Only update snapshots when changes are intentional
+
+## Tool Configuration
+
+- Enable/disable tools at startup (see `TOOL_CONFIGURATION.md`)
+- Example: `node dist/esm/index.js --enable-tools list_styles_tool,create_style_tool`
+
+## PR Instructions
+
+- Branch naming: use `feature/`, `fix/`, or `chore/` prefixes
+- PR title format: `[mcp-devkit-server] <Title>`
+- Always run `npm run lint` and `npm test` before committing
+- Keep PRs focused and well-described
+
+## Security & Tokens
+
+- Each tool requires specific Mapbox token scopes (see `README.md`)
+- Using insufficient scopes will result in errors
+- Use `VERBOSE_ERRORS=true` for detailed error output
+
+## Agent Tips
+
+- Mention files/folders explicitly for agents to read or edit
+- Use `/clear` to reset context between tasks (Claude Code)
+- Use checklists in Markdown for large refactors or multi-step tasks
+- Prefer running single tests for performance
+
+## Large Monorepo?
+
+- Place additional AGENTS.md files in subprojects if needed; the closest file to the code being edited takes precedence
+
+---
+
+_Edit this file to keep coding agents up to date on project standards, commands, and best practices._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — Mapbox MCP DevKit Server
+
+This file provides Claude and developers with essential context, commands, and standards for working with the Mapbox MCP DevKit Server. It follows [Anthropic's CLAUDE.md best practices](https://www.anthropic.com/engineering/claude-code-best-practices).
+
+---
+
+## Common Bash Commands
+
+- `npm run build` — Build the project
+- `npm test` — Run all tests
+- `npm run lint` — Run ESLint
+- `npm run lint:fix` — Auto-fix lint issues
+- `npm run format` — Check formatting with Prettier
+- `npm run format:fix` — Auto-format code
+- `npx plop create-tool` — Generate a new tool scaffold
+- `npx @modelcontextprotocol/inspector node dist/esm/index.js` — Inspect the MCP server
+- `npx @anthropic-ai/dxt pack` — Create a DXT package for distribution
+- `docker build -t mapbox-mcp-devkit .` — Build Docker image
+- `docker run mapbox/mcp-devkit-server ...` — Run server in Docker
+
+## Core Files & Structure
+
+- `src/tools/` — All tool implementations (see subfolders for each tool)
+- `src/resources/` — Resource classes and registries
+- `src/config/` — Tool and server configuration
+- `test/` — Unit and snapshot tests
+- `manifest.json` — DXT/extension manifest
+- `TOOL_CONFIGURATION.md` — Tool enable/disable and configuration guide
+- `README.md` — Main project documentation
+
+## Code Style Guidelines
+
+- Use TypeScript (strict mode enabled)
+- Prefer ES module syntax (`import`/`export`)
+- Destructure imports when possible
+- Follow snake_case for tool names (e.g., `list_styles_tool`)
+- Tool input schemas live in `*.schema.ts` files, separate from implementation
+- Use Zod for schema validation
+- Run Prettier and ESLint before committing
+
+## Testing Instructions
+
+- Run all tests: `npm test`
+- Update tool snapshot tests after adding/removing tools:
+  - `npm test -- src/tools/tool-naming-convention.test.ts --updateSnapshot`
+- Run a single test file: `npm test -- path/to/testfile.ts`
+- Only update snapshots when changes are intentional
+
+## Repository Etiquette
+
+- Prefer squash merges for PRs
+- Keep PRs focused and well-described
+- Update `CLAUDE.md` and `README.md` when adding new tools or workflows
+
+## Developer Environment Setup
+
+- Requires Node.js 22+
+- Install dependencies: `npm install`
+- Set `MAPBOX_ACCESS_TOKEN` in your environment (see `manifest.json` and `README.md`)
+- For Claude Code integration, see `docs/claude-code-integration.md`
+
+## Tool Configuration
+
+- Tools can be enabled/disabled at startup (see `TOOL_CONFIGURATION.md`)
+- Example: `node dist/esm/index.js --enable-tools list_styles_tool,create_style_tool`
+
+## Mapbox Token Scopes
+
+- Each tool requires specific Mapbox token scopes (see `README.md` for details)
+- Using insufficient scopes will result in errors
+
+## Known Issues & Warnings
+
+- Large GeoJSON files may cause slow performance in preview tools
+- Always check token scopes if a tool fails with authentication errors
+- Use `VERBOSE_ERRORS=true` for detailed error output
+
+## Claude Code Usage Tips
+
+- Mention files/folders explicitly for Claude to read or edit
+- Use `/clear` to reset context between tasks
+- Use checklists in Markdown for large refactors or multi-step tasks
+- Prefer running single tests for performance
+- Use `claude mcp add ...` to add this server to Claude Code
+
+## Additional Resources
+
+- [TOOL_CONFIGURATION.md](./TOOL_CONFIGURATION.md) — Tool config and usage
+- [docs/claude-code-integration.md](./docs/claude-code-integration.md) — Claude Code integration
+- [README.md](./README.md) — Project overview and tool documentation
+
+---
+
+_Edit this file to keep Claude and your team up to date on project standards, commands, and best practices._

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Model Context Protocol (MCP) server that provides AI assistants with direct ac
     - [Integration with Developer Tools](#integration-with-developer-tools)
     - [DXT Package Distribution](#dxt-package-distribution)
       - [Creating the DXT Package](#creating-the-dxt-package)
+    - [Hosted MCP Endpoint](#hosted-mcp-endpoint)
     - [Getting Your Mapbox Access Token](#getting-your-mapbox-access-token)
   - [Tools](#tools)
     - [Documentation Tools](#documentation-tools)
@@ -32,6 +33,7 @@ A Model Context Protocol (MCP) server that provides AI assistants with direct ac
     - [Creating New Tools](#creating-new-tools)
     - [Environment Variables](#environment-variables)
       - [VERBOSE_ERRORS](#verbose_errors)
+  - [Contributing](#contributing)
 
 ## Quick Start
 
@@ -496,3 +498,11 @@ src/tools/your-tool-name-tool/
 Set `VERBOSE_ERRORS=true` to get detailed error messages from the MCP server. This is useful for debugging issues when integrating with MCP clients.
 
 By default, the server returns generic error messages. With verbose errors enabled, you'll receive the actual error details, which can help diagnose API connection issues, invalid parameters, or other problems.
+
+## Contributing
+
+We welcome contributions to the Mapbox Development MCP Server! Please review our standards and guidelines before contributing:
+
+- **[Engineering Standards (CLAUDE.md)](./CLAUDE.md)** - Code quality, testing, documentation, and collaboration standards for all contributors
+- **[AI Agent Instructions (AGENTS.md)](./AGENTS.md)** - Comprehensive guide for AI agents working with this codebase
+- **[GitHub Copilot Guidelines](./.github/copilot-instructions.md)** - Best practices for using GitHub Copilot responsibly in this project


### PR DESCRIPTION
## Description

Adds AI tools helpers for the following:
- [AGENTS.md](https://agents.md/)
- [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices)
- [GitHub Copilot Instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)

---

## Testing

N/A

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
