### PR TITLE
Add Tools Annotation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@mapbox/mcp-devkit-server",
       "version": "0.4.0",
-      "license": "BSD-3-Clause",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "zod": "^3.25.42"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-devkit-server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-devkit-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Mapbox MCP devkit server",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build": "npm run prepare && npm run sync-manifest-version && tshy && npm run generate-version && node scripts/build-helpers.cjs copy-json && node scripts/add-shebang.cjs",
     "generate-version": "node scripts/build-helpers.cjs generate-version",
     "sync-manifest-version": "node scripts/build-helpers.cjs sync-manifest-version",
-    "dev": "tsc -p tsconfig.json --watch"
+    "dev": "tsc -p tsconfig.json --watch",
+    "dev:inspect": "npm run build && npx @modelcontextprotocol/inspector -e MAPBOX_ACCESS_TOKEN=\"$MAPBOX_ACCESS_PRIVATE_TOKEN\" node dist/esm/index.js"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix",

--- a/src/tools/bounding-box-tool/BoundingBoxTool.ts
+++ b/src/tools/bounding-box-tool/BoundingBoxTool.ts
@@ -16,6 +16,13 @@ export class BoundingBoxTool extends BaseTool<typeof BoundingBoxSchema> {
   readonly name = 'bounding_box_tool';
   readonly description =
     'Calculates bounding box of given GeoJSON content, returns as [minX, minY, maxX, maxY]';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Calculate GeoJSON Bounding Box Tool'
+  };
 
   constructor() {
     super({ inputSchema: BoundingBoxSchema });

--- a/src/tools/bounding-box-tool/CountryBoundingBoxTool.ts
+++ b/src/tools/bounding-box-tool/CountryBoundingBoxTool.ts
@@ -11,6 +11,13 @@ export class CountryBoundingBoxTool extends BaseTool<
   readonly name = 'country_bounding_box_tool';
   readonly description =
     'Gets bounding box for a country by its ISO 3166-1 country code, returns as [minX, minY, maxX, maxY].';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Get Country Bounding Box Tool'
+  };
 
   private boundariesData: Record<string, [number, number, number, number]> =
     boundariesData as unknown as Record<

--- a/src/tools/coordinate-conversion-tool/CoordinateConversionTool.ts
+++ b/src/tools/coordinate-conversion-tool/CoordinateConversionTool.ts
@@ -10,6 +10,13 @@ export class CoordinateConversionTool extends BaseTool<
   readonly name = 'coordinate_conversion_tool';
   readonly description =
     'Converts coordinates between WGS84 (longitude/latitude) and EPSG:3857 (Web Mercator) coordinate systems';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Convert Coordinates Tool'
+  };
 
   constructor() {
     super({ inputSchema: CoordinateConversionSchema });

--- a/src/tools/create-style-tool/CreateStyleTool.ts
+++ b/src/tools/create-style-tool/CreateStyleTool.ts
@@ -11,6 +11,13 @@ export class CreateStyleTool extends MapboxApiBasedTool<
 > {
   name = 'create_style_tool';
   description = 'Create a new Mapbox style';
+  readonly annotations = {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+    title: 'Create Mapbox Style Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: CreateStyleSchema });

--- a/src/tools/create-token-tool/CreateTokenTool.ts
+++ b/src/tools/create-token-tool/CreateTokenTool.ts
@@ -11,6 +11,13 @@ export class CreateTokenTool extends MapboxApiBasedTool<
   readonly name = 'create_token_tool';
   readonly description =
     'Create a new Mapbox public access token with specified scopes and optional URL restrictions.';
+  readonly annotations = {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+    title: 'Create Mapbox Token Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: CreateTokenSchema });

--- a/src/tools/delete-style-tool/DeleteStyleTool.ts
+++ b/src/tools/delete-style-tool/DeleteStyleTool.ts
@@ -10,6 +10,13 @@ export class DeleteStyleTool extends MapboxApiBasedTool<
 > {
   name = 'delete_style_tool';
   description = 'Delete a Mapbox style by ID';
+  readonly annotations = {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'Delete Mapbox Style Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: DeleteStyleSchema });

--- a/src/tools/geojson-preview-tool/GeojsonPreviewTool.ts
+++ b/src/tools/geojson-preview-tool/GeojsonPreviewTool.ts
@@ -9,6 +9,13 @@ export class GeojsonPreviewTool extends BaseTool<typeof GeojsonPreviewSchema> {
   name = 'geojson_preview_tool';
   description =
     'Generate a geojson.io URL to visualize GeoJSON data. Returns only the URL link.';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Preview GeoJSON Data Tool'
+  };
 
   constructor() {
     super({ inputSchema: GeojsonPreviewSchema });

--- a/src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts
+++ b/src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts
@@ -11,6 +11,13 @@ export class GetMapboxDocSourceTool extends BaseTool<
   name = 'get_latest_mapbox_docs_tool';
   description =
     'Get the latest official Mapbox documentation, APIs, SDKs, and developer resources directly from Mapbox. Always up-to-date, comprehensive coverage of all current Mapbox services including mapping, navigation, search, geocoding, and mobile SDKs. Use this for accurate, official Mapbox information instead of web search.';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'Get Mapbox Documentation Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: GetMapboxDocSourceSchema });

--- a/src/tools/list-styles-tool/ListStylesTool.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.ts
@@ -8,6 +8,13 @@ export class ListStylesTool extends MapboxApiBasedTool<
   name = 'list_styles_tool';
   description =
     'List styles for a Mapbox account. Use limit parameter to avoid large responses (recommended: limit=5-10). Use start parameter for pagination.';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'List Mapbox Styles Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: ListStylesSchema });

--- a/src/tools/list-tokens-tool/ListTokensTool.ts
+++ b/src/tools/list-tokens-tool/ListTokensTool.ts
@@ -8,6 +8,13 @@ export class ListTokensTool extends MapboxApiBasedTool<
   readonly name = 'list_tokens_tool';
   readonly description =
     'List Mapbox access tokens for the authenticated user with optional filtering and pagination. When using pagination, the "start" parameter must be obtained from the "next_start" field of the previous response (it is not a token ID)';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'List Mapbox Tokens Tool'
+  };
 
   constructor(private fetchImpl: typeof fetch = fetchClient) {
     super({ inputSchema: ListTokensSchema });

--- a/src/tools/preview-style-tool/PreviewStyleTool.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.ts
@@ -9,6 +9,13 @@ export class PreviewStyleTool extends BaseTool<typeof PreviewStyleSchema> {
   readonly name = 'preview_style_tool';
   readonly description =
     'Generate preview URL for a Mapbox style using an existing public token';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Preview Mapbox Style Tool'
+  };
 
   constructor() {
     super({ inputSchema: PreviewStyleSchema });

--- a/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
+++ b/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
@@ -11,6 +11,13 @@ export class RetrieveStyleTool extends MapboxApiBasedTool<
 > {
   name = 'retrieve_style_tool';
   description = 'Retrieve a specific Mapbox style by ID';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'Retrieve Mapbox Style Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: RetrieveStyleSchema });

--- a/src/tools/style-builder-tool/StyleBuilderTool.ts
+++ b/src/tools/style-builder-tool/StyleBuilderTool.ts
@@ -53,6 +53,13 @@ const SOURCE_LAYER_GEOMETRY: Record<
 export class StyleBuilderTool extends BaseTool<typeof StyleBuilderToolSchema> {
   name = 'style_builder_tool';
   private currentSourceLayer?: string; // Track current source layer for better error messages
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Build Mapbox Style JSON Tool'
+  };
   description = `Generate Mapbox style JSON for creating new styles or updating existing ones.
 
 The tool intelligently resolves layer types and filter properties using Streets v8 data.

--- a/src/tools/style-comparison-tool/StyleComparisonTool.ts
+++ b/src/tools/style-comparison-tool/StyleComparisonTool.ts
@@ -11,6 +11,13 @@ export class StyleComparisonTool extends BaseTool<
   readonly name = 'style_comparison_tool';
   readonly description =
     'Generate a comparison URL for comparing two Mapbox styles side-by-side';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    title: 'Compare Mapbox Styles Tool'
+  };
 
   constructor() {
     super({ inputSchema: StyleComparisonSchema });

--- a/src/tools/tilequery-tool/TilequeryTool.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.ts
@@ -6,6 +6,13 @@ export class TilequeryTool extends MapboxApiBasedTool<typeof TilequerySchema> {
   name = 'tilequery_tool';
   description =
     'Query vector and raster data from Mapbox tilesets at geographic coordinates';
+  readonly annotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+    title: 'Mapbox Tilequery Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: TilequerySchema });

--- a/src/tools/update-style-tool/UpdateStyleTool.ts
+++ b/src/tools/update-style-tool/UpdateStyleTool.ts
@@ -11,6 +11,13 @@ export class UpdateStyleTool extends MapboxApiBasedTool<
 > {
   name = 'update_style_tool';
   description = 'Update an existing Mapbox style';
+  readonly annotations = {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+    title: 'Update Mapbox Style Tool'
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: UpdateStyleSchema });


### PR DESCRIPTION
This pull request introduces a new standardized annotations property to all tool classes in the codebase, providing structured metadata about each tool's behavior (such as whether it is read-only, destructive, idempotent, etc.). Additionally, the `BaseTool` and related registration logic are updated to require and propagate these annotations. There are also minor updates to the development workflow in `package.json`.

**Tool metadata standardization:**

* Added a required `annotations` property (of type `ToolAnnotations`) to the `BaseTool` class and all tool implementations, describing each tool's characteristics (e.g., read-only, destructive, idempotent, open-world, and a human-friendly title). (`src/tools/BaseTool.ts`, `src/tools/bounding-box-tool/BoundingBoxTool.ts`, `src/tools/bounding-box-tool/CountryBoundingBoxTool.ts`, `src/tools/coordinate-conversion-tool/CoordinateConversionTool.ts`, `src/tools/create-style-tool/CreateStyleTool.ts`, `src/tools/create-token-tool/CreateTokenTool.ts`, `src/tools/delete-style-tool/DeleteStyleTool.ts`, `src/tools/geojson-preview-tool/GeojsonPreviewTool.ts`, `src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts`, `src/tools/list-styles-tool/ListStylesTool.ts`, `src/tools/list-tokens-tool/ListTokensTool.ts`, `src/tools/preview-style-tool/PreviewStyleTool.ts`, `src/tools/retrieve-style-tool/RetrieveStyleTool.ts`, `src/tools/style-builder-tool/StyleBuilderTool.ts`, `src/tools/style-comparison-tool/StyleComparisonTool.ts`, `src/tools/tilequery-tool/TilequeryTool.ts`, `src/tools/update-style-tool/UpdateStyleTool.ts`) [[1]](diffhunk://#diff-d5c12690c04974ef40ca8c1d77abf0ad06a9fdd2bc5e57c9616df79cef313362R32) [[2]](diffhunk://#diff-2649ddc019ac9a5ab729f1e2a7227baf455c38a32d26654d00f133404d4131b5R19-R25) [[3]](diffhunk://#diff-24ed07037d888010a0f93fba68f5a2a5e58971539b293833d3f1bfa159695803R14-R20) [[4]](diffhunk://#diff-a2e0bfc5931536260dcb603f0b7d6320a25916d117c84c2c35eb25414cd51b9aR13-R19) [[5]](diffhunk://#diff-604ba9cc0504693c8733cf732e3d39df8f8cb4f78312672db435660b707db6c5R14-R20) [[6]](diffhunk://#diff-0f5fa571a0af744d62d340f8e6c9e4d83a22ac0bc395a16b980cb4820d4c381eR14-R20) [[7]](diffhunk://#diff-5fd53fe61130a4a0c054092520a49f28a90427f3f0a8f51503426982ba9c5383R13-R19) [[8]](diffhunk://#diff-f8ca3aa47a6d44305742fb70a113897f8090352227edddc12770d47d6a1efcd8R12-R18) [[9]](diffhunk://#diff-15a535de501ab1bccbdf3ac1ceb190d6f1498df1ec6fb9c3fc6d47a8b584f41fR14-R20) [[10]](diffhunk://#diff-d6b24c862c824ac29e8d7f9606399fcc87001c1b329ff74640893dbda75e03caR11-R17) [[11]](diffhunk://#diff-e67efc4755e9efe0f8b26ab8d8218497fd6ec0441dca5a23115a323b8b8086e9R11-R17) [[12]](diffhunk://#diff-26c2fdd40b59acffef62dde20ec585daffa2c501af98f7797ccf1714d596a4aaR12-R18) [[13]](diffhunk://#diff-be98cced6c224bbcc70ff8f4a676d1387769ee72ad4b49cb03b8a8cd32f7e663R14-R20) [[14]](diffhunk://#diff-c8e384ce92d829f692193f6f2177e611d43098ffb01d0c6257b95e8ecf8fdb97R56-R62) [[15]](diffhunk://#diff-6712095329dee32d9694214146ee1597b500008be42c356938fd920097ea296fR14-R20) [[16]](diffhunk://#diff-9fda1bb0e3294e30d87c05c989a95335f1358c1805ff727733eef507a28399e3R9-R15) [[17]](diffhunk://#diff-0e691600ede135c4a47968f2f62815c8ebcee135057e542031ff56fae59bd2bbR14-R20)

* Updated the `BaseTool.installTo` method to use `server.registerTool` and pass the new annotations property as part of tool registration, ensuring this metadata is available at runtime.

**Development workflow improvements:**

* Added a new `dev:inspect` script to `package.json` for easier debugging with the inspector, and bumped the package version to `0.4.1`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R23)

**Dependency and import updates:**

* Imported `ToolAnnotations` type from the SDK in `BaseTool.ts` to support the new annotations property.