### PR TITLE
[tools] Update schemas to not fail upon parsing

### DIFF
--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -107,4 +107,26 @@ export abstract class BaseTool<
       this.server.server.sendLoggingMessage({ level, data });
     }
   }
+
+  /**
+   * Validates output data against the output schema.
+   * If validation fails, logs a warning and returns the raw data instead of throwing an error.
+   * This allows tools to continue functioning when API responses deviate from expected schemas.
+   */
+  protected validateOutput<T>(
+    schema: ZodTypeAny,
+    rawData: unknown,
+    toolName: string
+  ): T {
+    try {
+      return schema.parse(rawData) as T;
+    } catch (validationError) {
+      this.log(
+        'warning',
+        `${toolName}: Output schema validation failed - ${validationError instanceof Error ? validationError.message : 'Unknown validation error'}`
+      );
+      // Graceful fallback to raw data
+      return rawData as T;
+    }
+  }
 }

--- a/src/tools/create-token-tool/CreateTokenTool.ts
+++ b/src/tools/create-token-tool/CreateTokenTool.ts
@@ -90,33 +90,25 @@ export class CreateTokenTool extends MapboxApiBasedTool<
       return this.handleApiError(response, 'create token');
     }
 
-    const data = await response.json();
-    const parseResult = CreateTokenOutputSchema.safeParse(data);
-    if (!parseResult.success) {
-      this.log(
-        'error',
-        `CreateTokenTool: Output schema validation failed\n${parseResult.error}`
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `CreateTokenTool: Response does not conform to output schema:\n${parseResult.error}`
-          }
-        ],
-        isError: true
-      };
-    }
+    const rawData = await response.json();
+
+    // Validate response against schema with graceful fallback
+    const data = this.validateOutput<Record<string, unknown>>(
+      CreateTokenOutputSchema,
+      rawData,
+      'CreateTokenTool'
+    );
+
     this.log('info', `CreateTokenTool: Successfully created token`);
 
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(parseResult.data, null, 2)
+          text: JSON.stringify(data, null, 2)
         }
       ],
-      structuredContent: parseResult.data,
+      structuredContent: data,
       isError: false
     };
   }

--- a/src/tools/list-styles-tool/ListStylesTool.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.ts
@@ -68,27 +68,18 @@ export class ListStylesTool extends MapboxApiBasedTool<
       return this.handleApiError(response, 'list styles');
     }
 
-    const data = await response.json();
-    // Validate the API response (which is an array)
-    const parseResult = StylesArraySchema.safeParse(data);
-    if (!parseResult.success) {
-      this.log(
-        'error',
-        `ListStylesTool: Output schema validation failed\n${parseResult.error}`
-      );
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `ListStylesTool: Response does not conform to output schema:\n${parseResult.error}`
-          }
-        ],
-        isError: true
-      };
-    }
+    const rawData = await response.json();
+
+    // Validate the API response (which is an array) with graceful fallback
+    const validatedData = this.validateOutput(
+      StylesArraySchema,
+      rawData,
+      'ListStylesTool'
+    );
+
     this.log('info', `ListStylesTool: Successfully listed styles`);
 
-    const wrappedData = { styles: parseResult.data };
+    const wrappedData = { styles: validatedData };
     return {
       content: [
         {

--- a/src/tools/list-tokens-tool/ListTokensTool.ts
+++ b/src/tools/list-tokens-tool/ListTokensTool.ts
@@ -130,24 +130,14 @@ export class ListTokensTool extends MapboxApiBasedTool<
           ? data
           : (data as { tokens?: unknown[] }).tokens || [];
 
-        // Validate tokens array against TokenObjectSchema
-        const parseResult = TokenObjectSchema.array().safeParse(tokens);
-        if (!parseResult.success) {
-          this.log(
-            'error',
-            `ListTokensTool: Token array schema validation failed\n${parseResult.error}`
-          );
-          return {
-            isError: true,
-            content: [
-              {
-                type: 'text',
-                text: `ListTokensTool: Response does not conform to token array schema:\n${parseResult.error}`
-              }
-            ]
-          };
-        }
-        allTokens.push(...parseResult.data);
+        // Validate tokens array against TokenObjectSchema with graceful fallback
+        const validatedTokens = this.validateOutput<unknown[]>(
+          TokenObjectSchema.array(),
+          tokens,
+          'ListTokensTool'
+        );
+
+        allTokens.push(...validatedTokens);
         this.log(
           'info',
           `ListTokensTool: Retrieved ${tokens.length} tokens on page ${pageCount}`


### PR DESCRIPTION
  ## Description

  Makes output schema validation non-fatal for tools, matching the pattern established in
  https://github.com/mapbox/mcp-server/pull/74.

  ### Changes

  **Added `validateOutput` helper to BaseTool** (src/tools/BaseTool.ts:111-132)
  - New protected method that validates output data against schemas
  - Logs warnings instead of throwing errors when validation fails
  - Returns raw data as graceful fallback, allowing tools to continue functioning

  **Updated 3 tools to use graceful validation:**
  - **ListStylesTool** - Replaced error-returning `safeParse` with `validateOutput` helper
  - **CreateTokenTool** - Replaced error-returning `safeParse` with `validateOutput` helper
  - **ListTokensTool** - Replaced error-returning `safeParse` with `validateOutput` helper

  ### Impact

  **Before:** When API responses deviated from expected schemas (but were still valid), tools would
   fail with schema validation errors.

  **After:** Tools log warnings and continue operating with raw data, improving resilience while
  maintaining debuggability through logged validation issues.

  ### Key Benefits

  ✅ **Non-fatal validation** - Schema mismatches log warnings instead of failing tool operations
  ✅ **Better resilience** - Tools work even when API responses change slightly
  ✅ **Maintained debuggability** - Validation failures still logged at warning level
  ✅ **Consistent pattern** - All tools follow the same graceful validation approach

  ## Tests

  ### New Unit Tests

  Added 3 unit tests verifying graceful schema validation fallback:

  1. **ListStylesTool** (test/tools/list-styles-tool/ListStylesTool.test.ts:271-313)
     - Verifies tool handles missing required fields (owner, created, modified)
     - Confirms warning is logged with "Output schema validation failed"
     - Ensures raw data is returned including unexpected fields

  2. **CreateTokenTool** (test/tools/create-token-tool/CreateTokenTool.test.ts:366-402)
     - Verifies tool handles missing required fields (id, created, modified)
     - Confirms warning is logged with "Output schema validation failed"
     - Ensures raw data is returned including unexpected fields

  3. **ListTokensTool** (test/tools/list-tokens-tool/ListTokensTool.test.ts:568-605)
     - Verifies tool handles missing required fields (usage, client, scopes)
     - Confirms warning is logged with "Output schema validation failed"
     - Ensures raw data is returned including unexpected fields

  ### Test Results

  ✅ All 286 tests passing (283 original + 3 new)
  ✅ Build successful
  ✅ No new linting issues

  Each test verifies three critical behaviors:
  1. ✅ No errors thrown (graceful degradation)
  2. ✅ Warning logged for debugging
  3. ✅ Raw data returned successfully

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
