### PR TITLE
Add Accept header for documentation fetching

### DIFF
--- a/src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts
+++ b/src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts
@@ -37,7 +37,12 @@ export class GetMapboxDocSourceTool extends BaseTool<
   ): Promise<CallToolResult> {
     try {
       const response = await this.httpRequest(
-        'https://docs.mapbox.com/llms.txt'
+        'https://docs.mapbox.com/llms.txt',
+        {
+          headers: {
+            Accept: 'text/markdown, text/plain;q=0.9, */*;q=0.8'
+          }
+        }
       );
 
       if (!response.ok) {

--- a/test/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.test.ts
+++ b/test/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.test.ts
@@ -43,6 +43,7 @@ This is the Mapbox developer documentation for LLMs.
       'https://docs.mapbox.com/llms.txt',
       {
         headers: {
+          Accept: 'text/markdown, text/plain;q=0.9, */*;q=0.8',
           'User-Agent': 'TestServer/1.0.0 (default, no-tag, abcdef)'
         }
       }


### PR DESCRIPTION
## Summary

Improves HTTP semantics by explicitly requesting `text/markdown` format when fetching Mapbox documentation from `docs.mapbox.com/llms.txt`.

## Why This Matters

While the current implementation works (the LLM correctly interprets markdown content served as `text/plain`), adding an explicit `Accept` header provides several benefits:

1. **HTTP Semantics** - Properly signals to the server what format we prefer
2. **Content Negotiation** - Enables server to return different formats based on client preference
3. **Future-Proofing** - Ready if Mapbox ever supports multiple documentation formats
4. **Self-Documenting** - Code clearly shows we expect markdown content
5. **Standards Compliance** - Follows RFC 7763 for markdown MIME types

## Changes

**Modified Files:**
- `src/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.ts` - Added Accept header with preference ordering
- `test/tools/get-mapbox-doc-source-tool/GetMapboxDocSourceTool.test.ts` - Updated test to verify header

**Accept Header Format:**
```
Accept: text/markdown, text/plain;q=0.9, */*;q=0.8
```

This says:
- **First preference**: `text/markdown` (what we expect)
- **Second preference**: `text/plain` (current server response, slightly lower priority)
- **Fallback**: Accept anything else as last resort

## Technical Details

**Current State:**
- Server returns: `Content-Type: text/plain`
- Content IS markdown: Has `#` headings, `-` lists, `>` blockquotes
- LLM handles it correctly (Claude understands markdown in plain text)

**What We Changed:**
- Added explicit `Accept` header when fetching
- Server response unchanged (still `text/plain`)
- MCP still returns as `type: 'text'` (correct - no native markdown type in MCP)
- LLM behavior unchanged (still works perfectly)

## Testing

- ✅ All 515 tests pass
- ✅ Build succeeds with no TypeScript errors
- ✅ Test verifies Accept header is passed correctly
- ✅ Backward compatible - doesn't change behavior, only adds proper HTTP header

## Manual Verification in MCP Inspector

Tested the implementation in MCP Inspector to confirm the Accept header is working correctly:

**Test Steps:**
1. Started MCP Inspector with `npm run inspect:build`
2. Called `get_latest_mapbox_docs_tool` with empty input
3. Verified markdown documentation is successfully fetched and returned

**Results:**
✅ Tool executes successfully with "Tool Result: Success"
✅ Returns properly formatted markdown content starting with `# Mapbox Documentation`
✅ Includes all expected sections (Maps client libraries & SDKs, Data loading & access APIs, etc.)
✅ No errors or issues with the Accept header implementation

Screenshots showing the successful execution are available at:

### `get_reference_tool`

<img width="554" height="501" alt="Screenshot 2026-01-15 at 12 45 10" src="https://github.com/user-attachments/assets/c191ec63-a679-4ce4-ba03-3f73656c2b4b" />

### `get_latest_mapbox_docs_tool`

<img width="544" height="475" alt="Screenshot 2026-01-15 at 12 45 22" src="https://github.com/user-attachments/assets/c99d1af3-42f8-4683-932d-c9077f432a86" />

## Benefits

**Professional API Citizenship** - Shows we follow HTTP best practices  
**Self-Documenting Code** - Accept header explicitly documents our intent  
**Protects Against Future Changes** - If server adds multi-format support, we're ready  
**No Breaking Changes** - Purely additive improvement