### PR TITLE
fix: prevent path traversal in style and tileset tool URL construction

### DIFF
--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -135,26 +135,4 @@ export abstract class BaseTool<
       this.server.server.sendLoggingMessage({ level, data });
     }
   }
-
-  /**
-   * Validates output data against the output schema.
-   * If validation fails, logs a warning and returns the raw data instead of throwing an error.
-   * This allows tools to continue functioning when API responses deviate from expected schemas.
-   */
-  protected validateOutput<T>(
-    schema: ZodTypeAny,
-    rawData: unknown,
-    toolName: string
-  ): T {
-    try {
-      return schema.parse(rawData) as T;
-    } catch (validationError) {
-      this.log(
-        'warning',
-        `${toolName}: Output schema validation failed - ${validationError instanceof Error ? validationError.message : 'Unknown validation error'}`
-      );
-      // Graceful fallback to raw data
-      return rawData as T;
-    }
-  }
 }

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -13,6 +13,11 @@ import { context, trace, SpanStatusCode } from '@opentelemetry/api';
 import type { ToolExecutionContext } from '../utils/tracing.js';
 import { createToolExecutionContext } from '../utils/tracing.js';
 
+/** Remove access_token query parameter values from strings before logging or returning to callers. */
+export function redactToken(s: string): string {
+  return s.replace(/access_token=[^&\s#"']+/g, 'access_token=***');
+}
+
 /**
  * Standard error response format from Mapbox API
  */
@@ -126,8 +131,8 @@ export abstract class MapboxApiBasedTool<
       toolContext.span.end();
       return result;
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = redactToken(rawMessage);
       this.log(
         'error',
         `${this.name}: Error during execution: ${errorMessage}`

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -217,6 +217,18 @@ export abstract class MapboxApiBasedTool<
     };
   }
 
+  protected handleValidationError(error: unknown): CallToolResult {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Unexpected API response format from Mapbox API: ${error instanceof Error ? error.message : 'Unknown validation error'}`
+        }
+      ]
+    };
+  }
+
   /**
    * Tool logic to be implemented by subclasses.
    * Must return a complete OutputSchema with content and optional structured content.

--- a/src/tools/create-token-tool/CreateTokenTool.ts
+++ b/src/tools/create-token-tool/CreateTokenTool.ts
@@ -95,16 +95,8 @@ export class CreateTokenTool extends MapboxApiBasedTool<
     let data;
     try {
       data = CreateTokenOutputSchema.parse(rawData);
-    } catch {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: 'Unexpected API response format from Mapbox API'
-          }
-        ]
-      };
+    } catch (validationError) {
+      return this.handleValidationError(validationError);
     }
 
     this.log('info', `CreateTokenTool: Successfully created token`);

--- a/src/tools/create-token-tool/CreateTokenTool.ts
+++ b/src/tools/create-token-tool/CreateTokenTool.ts
@@ -92,12 +92,20 @@ export class CreateTokenTool extends MapboxApiBasedTool<
 
     const rawData = await response.json();
 
-    // Validate response against schema with graceful fallback
-    const data = this.validateOutput<Record<string, unknown>>(
-      CreateTokenOutputSchema,
-      rawData,
-      'CreateTokenTool'
-    );
+    let data;
+    try {
+      data = CreateTokenOutputSchema.parse(rawData);
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Unexpected API response format from Mapbox API'
+          }
+        ]
+      };
+    }
 
     this.log('info', `CreateTokenTool: Successfully created token`);
 

--- a/src/tools/delete-style-tool/DeleteStyleTool.input.schema.ts
+++ b/src/tools/delete-style-tool/DeleteStyleTool.input.schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
+import { styleIdSchema } from '../shared/styleId.schema.js';
 
 export const DeleteStyleSchema = z.object({
-  styleId: z.string().describe('Style ID to delete')
+  styleId: styleIdSchema.describe('Style ID to delete')
 });
 
 export type DeleteStyleInput = z.infer<typeof DeleteStyleSchema>;

--- a/src/tools/delete-style-tool/DeleteStyleTool.ts
+++ b/src/tools/delete-style-tool/DeleteStyleTool.ts
@@ -34,7 +34,7 @@ export class DeleteStyleTool extends MapboxApiBasedTool<
     _context: ToolExecutionContext
   ): Promise<CallToolResult> {
     const username = getUserNameFromToken(accessToken);
-    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${username}/${input.styleId}?access_token=${accessToken}`;
+    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${encodeURIComponent(username)}/${encodeURIComponent(input.styleId)}?access_token=${accessToken}`;
 
     const response = await this.httpRequest(url, {
       method: 'DELETE'

--- a/src/tools/list-styles-tool/ListStylesTool.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.ts
@@ -73,16 +73,8 @@ export class ListStylesTool extends MapboxApiBasedTool<
     let validatedData;
     try {
       validatedData = StylesArraySchema.parse(rawData);
-    } catch {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: 'Unexpected API response format from Mapbox API'
-          }
-        ]
-      };
+    } catch (validationError) {
+      return this.handleValidationError(validationError);
     }
 
     this.log('info', `ListStylesTool: Successfully listed styles`);

--- a/src/tools/list-styles-tool/ListStylesTool.ts
+++ b/src/tools/list-styles-tool/ListStylesTool.ts
@@ -70,12 +70,20 @@ export class ListStylesTool extends MapboxApiBasedTool<
 
     const rawData = await response.json();
 
-    // Validate the API response (which is an array) with graceful fallback
-    const validatedData = this.validateOutput(
-      StylesArraySchema,
-      rawData,
-      'ListStylesTool'
-    );
+    let validatedData;
+    try {
+      validatedData = StylesArraySchema.parse(rawData);
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Unexpected API response format from Mapbox API'
+          }
+        ]
+      };
+    }
 
     this.log('info', `ListStylesTool: Successfully listed styles`);
 

--- a/src/tools/list-tokens-tool/ListTokensTool.ts
+++ b/src/tools/list-tokens-tool/ListTokensTool.ts
@@ -133,16 +133,8 @@ export class ListTokensTool extends MapboxApiBasedTool<
         let validatedTokens;
         try {
           validatedTokens = TokenObjectSchema.array().parse(tokens);
-        } catch {
-          return {
-            isError: true,
-            content: [
-              {
-                type: 'text',
-                text: 'Unexpected API response format from Mapbox API'
-              }
-            ]
-          };
+        } catch (validationError) {
+          return this.handleValidationError(validationError);
         }
 
         allTokens.push(...validatedTokens);

--- a/src/tools/list-tokens-tool/ListTokensTool.ts
+++ b/src/tools/list-tokens-tool/ListTokensTool.ts
@@ -4,7 +4,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { HttpRequest } from '../../utils/types.js';
 import type { ToolExecutionContext } from '../../utils/tracing.js';
-import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
+import { MapboxApiBasedTool, redactToken } from '../MapboxApiBasedTool.js';
 import {
   ListTokensSchema,
   ListTokensInput
@@ -110,7 +110,7 @@ export class ListTokensTool extends MapboxApiBasedTool<
       while (url) {
         pageCount++;
         this.log('info', `ListTokensTool: Fetching page ${pageCount}`);
-        this.log('debug', `ListTokensTool: Fetching URL: ${url}`);
+        this.log('debug', `ListTokensTool: Fetching URL: ${redactToken(url)}`);
 
         const response = await this.httpRequest(url, {
           method: 'GET',
@@ -157,26 +157,34 @@ export class ListTokensTool extends MapboxApiBasedTool<
         if (linkHeader) {
           const links = this.parseLinkHeader(linkHeader);
           if (links.next) {
-            // Ensure the next URL includes the access token
             const nextUrl = new URL(links.next);
-            if (!nextUrl.searchParams.has('access_token')) {
-              nextUrl.searchParams.append('access_token', accessToken);
-            }
-            const nextUrlString = nextUrl.toString();
-
-            if (shouldAutoPaginate) {
-              url = nextUrlString;
-              this.log('info', `ListTokensTool: Next page available: ${url}`);
+            // Reject cross-origin Link headers to prevent token exfiltration
+            const apiOrigin = new URL(ListTokensTool.mapboxApiEndpoint).origin;
+            if (nextUrl.origin !== apiOrigin) {
+              this.log(
+                'warning',
+                `ListTokensTool: Refusing cross-origin Link header: ${nextUrl.origin}`
+              );
             } else {
-              // For manual pagination, extract the start parameter from the next URL
-              const nextUrl = new URL(links.next);
-              const startParam = nextUrl.searchParams.get('start');
-              if (startParam) {
-                nextPageUrl = startParam;
-                this.log(
-                  'info',
-                  `ListTokensTool: Next page start token saved for manual pagination: ${nextPageUrl}`
-                );
+              // Ensure the next URL includes the access token
+              if (!nextUrl.searchParams.has('access_token')) {
+                nextUrl.searchParams.append('access_token', accessToken);
+              }
+              const nextUrlString = nextUrl.toString();
+
+              if (shouldAutoPaginate) {
+                url = nextUrlString;
+                this.log('info', 'ListTokensTool: Next page available');
+              } else {
+                // For manual pagination, extract the start parameter from the next URL
+                const startParam = nextUrl.searchParams.get('start');
+                if (startParam) {
+                  nextPageUrl = startParam;
+                  this.log(
+                    'info',
+                    'ListTokensTool: Next page start token saved for manual pagination'
+                  );
+                }
               }
             }
           }

--- a/src/tools/list-tokens-tool/ListTokensTool.ts
+++ b/src/tools/list-tokens-tool/ListTokensTool.ts
@@ -130,12 +130,20 @@ export class ListTokensTool extends MapboxApiBasedTool<
           ? data
           : (data as { tokens?: unknown[] }).tokens || [];
 
-        // Validate tokens array against TokenObjectSchema with graceful fallback
-        const validatedTokens = this.validateOutput<unknown[]>(
-          TokenObjectSchema.array(),
-          tokens,
-          'ListTokensTool'
-        );
+        let validatedTokens;
+        try {
+          validatedTokens = TokenObjectSchema.array().parse(tokens);
+        } catch {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: 'Unexpected API response format from Mapbox API'
+              }
+            ]
+          };
+        }
 
         allTokens.push(...validatedTokens);
         this.log(

--- a/src/tools/preview-style-tool/PreviewStyleTool.input.schema.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.input.schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
+import { styleIdSchema } from '../shared/styleId.schema.js';
 
 export const PreviewStyleSchema = z.object({
-  styleId: z.string().describe('Style ID to preview'),
+  styleId: styleIdSchema.describe('Style ID to preview'),
   accessToken: z
     .string()
     .startsWith(

--- a/src/tools/preview-style-tool/PreviewStyleTool.ts
+++ b/src/tools/preview-style-tool/PreviewStyleTool.ts
@@ -74,7 +74,7 @@ export class PreviewStyleTool extends BaseTool<typeof PreviewStyleSchema> {
     const hashFragment =
       hashParams.length > 0 ? `#${hashParams.join('/')}` : '';
 
-    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${userName}/${input.styleId}.html?${params.toString()}${hashFragment}`;
+    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${encodeURIComponent(userName)}/${encodeURIComponent(input.styleId)}.html?${params.toString()}${hashFragment}`;
 
     // Build content array with URL
     const content: CallToolResult['content'] = [
@@ -86,7 +86,7 @@ export class PreviewStyleTool extends BaseTool<typeof PreviewStyleSchema> {
 
     // Add MCP-UI resource (for legacy MCP-UI clients)
     const uiResource = createUIResource({
-      uri: `ui://mapbox/preview-style/${userName}/${input.styleId}`,
+      uri: `ui://mapbox/preview-style/${encodeURIComponent(userName)}/${encodeURIComponent(input.styleId)}`,
       content: {
         type: 'externalUrl',
         iframeUrl: url

--- a/src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.ts
+++ b/src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
+import { styleIdSchema } from '../shared/styleId.schema.js';
 
 export const RetrieveStyleSchema = z.object({
-  styleId: z.string().describe('Style ID to retrieve')
+  styleId: styleIdSchema.describe('Style ID to retrieve')
 });
 
 export type RetrieveStyleInput = z.infer<typeof RetrieveStyleSchema>;

--- a/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
+++ b/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
@@ -57,16 +57,8 @@ export class RetrieveStyleTool extends MapboxApiBasedTool<
     let data: MapboxStyleOutput;
     try {
       data = MapboxStyleOutputSchema.parse(rawData);
-    } catch {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: 'Unexpected API response format from Mapbox API'
-          }
-        ]
-      };
+    } catch (validationError) {
+      return this.handleValidationError(validationError);
     }
 
     this.log(

--- a/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
+++ b/src/tools/retrieve-style-tool/RetrieveStyleTool.ts
@@ -44,7 +44,7 @@ export class RetrieveStyleTool extends MapboxApiBasedTool<
     _context: ToolExecutionContext
   ): Promise<CallToolResult> {
     const username = getUserNameFromToken(accessToken);
-    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${username}/${input.styleId}?access_token=${accessToken}`;
+    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${encodeURIComponent(username)}/${encodeURIComponent(input.styleId)}?access_token=${accessToken}`;
 
     const response = await this.httpRequest(url);
 
@@ -57,16 +57,22 @@ export class RetrieveStyleTool extends MapboxApiBasedTool<
     let data: MapboxStyleOutput;
     try {
       data = MapboxStyleOutputSchema.parse(rawData);
-    } catch (validationError) {
-      this.log(
-        'warning',
-        `Schema validation failed for search response: ${validationError instanceof Error ? validationError.message : 'Unknown validation error'}`
-      );
-      // Graceful fallback to raw data
-      data = rawData as MapboxStyleOutput;
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Unexpected API response format from Mapbox API'
+          }
+        ]
+      };
     }
 
-    this.log('info', `UpdateStyleTool: Successfully updated style ${data.id}`);
+    this.log(
+      'info',
+      `RetrieveStyleTool: Successfully retrieved style ${data.id}`
+    );
 
     return {
       content: [

--- a/src/tools/shared/styleId.schema.ts
+++ b/src/tools/shared/styleId.schema.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Mapbox, Inc.
+// Licensed under the MIT License.
+
+import { z } from 'zod';
+
+export const styleIdSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+    'Invalid Mapbox style ID (only lowercase letters, numbers, and hyphens allowed)'
+  )
+  .describe('Mapbox style ID');

--- a/src/tools/tilequery-tool/TilequeryTool.input.schema.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.input.schema.ts
@@ -6,6 +6,10 @@ import { z } from 'zod';
 export const TilequerySchema = z.object({
   tilesetId: z
     .string()
+    .regex(
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+      'Invalid tileset ID format (expected: owner.tileset-name)'
+    )
     .optional()
     .default('mapbox.mapbox-streets-v8')
     .describe('Tileset ID to query (default: mapbox.mapbox-streets-v8)'),

--- a/src/tools/tilequery-tool/TilequeryTool.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.ts
@@ -84,16 +84,8 @@ export class TilequeryTool extends MapboxApiBasedTool<
     let data: TilequeryResponse;
     try {
       data = TilequeryResponseSchema.parse(rawData);
-    } catch {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: 'Unexpected API response format from Mapbox API'
-          }
-        ]
-      };
+    } catch (validationError) {
+      return this.handleValidationError(validationError);
     }
 
     this.log(

--- a/src/tools/tilequery-tool/TilequeryTool.ts
+++ b/src/tools/tilequery-tool/TilequeryTool.ts
@@ -44,7 +44,7 @@ export class TilequeryTool extends MapboxApiBasedTool<
   ): Promise<CallToolResult> {
     const { tilesetId, longitude, latitude, ...queryParams } = input;
     const url = new URL(
-      `${MapboxApiBasedTool.mapboxApiEndpoint}v4/${tilesetId}/tilequery/${longitude},${latitude}.json`
+      `${MapboxApiBasedTool.mapboxApiEndpoint}v4/${encodeURIComponent(tilesetId)}/tilequery/${longitude},${latitude}.json`
     );
 
     if (queryParams.radius !== undefined) {
@@ -81,17 +81,19 @@ export class TilequeryTool extends MapboxApiBasedTool<
 
     const rawData = await response.json();
 
-    // Validate response against schema with graceful fallback
     let data: TilequeryResponse;
     try {
       data = TilequeryResponseSchema.parse(rawData);
-    } catch (validationError) {
-      this.log(
-        'warning',
-        `Schema validation failed for search response: ${validationError instanceof Error ? validationError.message : 'Unknown validation error'}`
-      );
-      // Graceful fallback to raw data
-      data = rawData as TilequeryResponse;
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Unexpected API response format from Mapbox API'
+          }
+        ]
+      };
     }
 
     this.log(

--- a/src/tools/update-style-tool/UpdateStyleTool.input.schema.ts
+++ b/src/tools/update-style-tool/UpdateStyleTool.input.schema.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { z } from 'zod';
+import { styleIdSchema } from '../shared/styleId.schema.js';
 
 // INPUT Schema - Accepts a complete Mapbox Style Specification as a generic object
 // This avoids complex schemas with .passthrough() that break some MCP clients (Cursor + OpenAI)
 export const UpdateStyleInputSchema = z.object({
-  styleId: z.string().describe('Style ID to update'),
+  styleId: styleIdSchema.describe('Style ID to update'),
   name: z.string().optional().describe('New name for the style'),
   style: z
     .record(z.string(), z.any())

--- a/src/tools/update-style-tool/UpdateStyleTool.ts
+++ b/src/tools/update-style-tool/UpdateStyleTool.ts
@@ -67,16 +67,8 @@ export class UpdateStyleTool extends MapboxApiBasedTool<
     let data: MapboxStyleOutput;
     try {
       data = MapboxStyleOutputSchema.parse(rawData);
-    } catch {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: 'Unexpected API response format from Mapbox API'
-          }
-        ]
-      };
+    } catch (validationError) {
+      return this.handleValidationError(validationError);
     }
 
     this.log('info', `UpdateStyleTool: Successfully updated style ${data.id}`);

--- a/src/tools/update-style-tool/UpdateStyleTool.ts
+++ b/src/tools/update-style-tool/UpdateStyleTool.ts
@@ -44,7 +44,7 @@ export class UpdateStyleTool extends MapboxApiBasedTool<
     _context: ToolExecutionContext
   ): Promise<CallToolResult> {
     const username = getUserNameFromToken(accessToken);
-    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${username}/${input.styleId}?access_token=${accessToken}`;
+    const url = `${MapboxApiBasedTool.mapboxApiEndpoint}styles/v1/${encodeURIComponent(username)}/${encodeURIComponent(input.styleId)}?access_token=${accessToken}`;
 
     const payload: Record<string, unknown> = {};
     if (input.name) payload.name = input.name;
@@ -67,13 +67,16 @@ export class UpdateStyleTool extends MapboxApiBasedTool<
     let data: MapboxStyleOutput;
     try {
       data = MapboxStyleOutputSchema.parse(rawData);
-    } catch (validationError) {
-      this.log(
-        'warning',
-        `Schema validation failed for search response: ${validationError instanceof Error ? validationError.message : 'Unknown validation error'}`
-      );
-      // Graceful fallback to raw data
-      data = rawData as MapboxStyleOutput;
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Unexpected API response format from Mapbox API'
+          }
+        ]
+      };
     }
 
     this.log('info', `UpdateStyleTool: Successfully updated style ${data.id}`);

--- a/test/security/path-traversal.test.ts
+++ b/test/security/path-traversal.test.ts
@@ -1,0 +1,305 @@
+// Copyright (c) Mapbox, Inc.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { RetrieveStyleSchema } from '../../src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.js';
+import { DeleteStyleSchema } from '../../src/tools/delete-style-tool/DeleteStyleTool.input.schema.js';
+import { UpdateStyleInputSchema } from '../../src/tools/update-style-tool/UpdateStyleTool.input.schema.js';
+import { PreviewStyleSchema } from '../../src/tools/preview-style-tool/PreviewStyleTool.input.schema.js';
+import { TilequerySchema } from '../../src/tools/tilequery-tool/TilequeryTool.input.schema.js';
+import { RetrieveStyleTool } from '../../src/tools/retrieve-style-tool/RetrieveStyleTool.js';
+import { UpdateStyleTool } from '../../src/tools/update-style-tool/UpdateStyleTool.js';
+import { TilequeryTool } from '../../src/tools/tilequery-tool/TilequeryTool.js';
+import { DeleteStyleTool } from '../../src/tools/delete-style-tool/DeleteStyleTool.js';
+import { PreviewStyleTool } from '../../src/tools/preview-style-tool/PreviewStyleTool.js';
+import { setupHttpRequest } from '../utils/httpPipelineUtils.js';
+
+// 25-char alphanumeric — a real Mapbox style ID format
+const VALID_STYLE_ID = 'cmojrmkc9002t01ry96yi6h48';
+const VALID_TILESET_ID = 'mapbox.mapbox-streets-v8';
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+const PUBLIC_MOCK_TOKEN =
+  'pk.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+
+function makeToken(username: string): string {
+  const header = 'eyJhbGciOiJIUzI1NiJ9';
+  const payload = Buffer.from(
+    JSON.stringify({ u: username, a: 'test-api' })
+  ).toString('base64');
+  return `${header}.${payload}.sig`;
+}
+
+function makePublicToken(username: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ u: username, a: 'test-api' })
+  ).toString('base64');
+  return `pk.${payload}.sig`;
+}
+
+const MOCK_STYLE_RESPONSE = {
+  id: VALID_STYLE_ID,
+  name: 'Test Style',
+  owner: 'test-user',
+  version: 8,
+  created: '2020-01-01T00:00:00.000Z',
+  modified: '2020-01-01T00:00:00.000Z',
+  visibility: 'private',
+  sources: {},
+  layers: []
+};
+
+beforeAll(() => {
+  process.env.MAPBOX_ACCESS_TOKEN = MOCK_TOKEN;
+});
+
+describe('path traversal security', () => {
+  const STYLE_TRAVERSAL_PAYLOADS = [
+    '../../../tokens/v2/testuser',
+    '../testuser',
+    `../testuser/${VALID_STYLE_ID}`,
+    'prefix/../../../escape',
+    '..%2F..%2Ftokens',
+    '%2E%2E%2F%2E%2E',
+    'valid\x00inject'
+  ];
+
+  const TILESET_TRAVERSAL_PAYLOADS = [
+    '../../tokens/v2/testuser',
+    '../mapbox/tileset',
+    'mapbox/../attacker',
+    '/absolute/path',
+    'nodothere'
+  ];
+
+  describe('styleId schema validation rejects traversal payloads', () => {
+    it.each(STYLE_TRAVERSAL_PAYLOADS)(
+      'RetrieveStyleSchema rejects "%s"',
+      (styleId) => {
+        expect(RetrieveStyleSchema.safeParse({ styleId }).success).toBe(false);
+      }
+    );
+
+    it.each(STYLE_TRAVERSAL_PAYLOADS)(
+      'DeleteStyleSchema rejects "%s"',
+      (styleId) => {
+        expect(DeleteStyleSchema.safeParse({ styleId }).success).toBe(false);
+      }
+    );
+
+    it.each(STYLE_TRAVERSAL_PAYLOADS)(
+      'UpdateStyleInputSchema rejects "%s"',
+      (styleId) => {
+        expect(UpdateStyleInputSchema.safeParse({ styleId }).success).toBe(
+          false
+        );
+      }
+    );
+
+    it.each(STYLE_TRAVERSAL_PAYLOADS)(
+      'PreviewStyleSchema rejects "%s"',
+      (styleId) => {
+        expect(
+          PreviewStyleSchema.safeParse({
+            styleId,
+            accessToken: PUBLIC_MOCK_TOKEN
+          }).success
+        ).toBe(false);
+      }
+    );
+  });
+
+  describe('tilesetId schema validation rejects traversal payloads', () => {
+    it.each(TILESET_TRAVERSAL_PAYLOADS)(
+      'TilequerySchema rejects "%s"',
+      (tilesetId) => {
+        expect(
+          TilequerySchema.safeParse({ tilesetId, longitude: 0, latitude: 0 })
+            .success
+        ).toBe(false);
+      }
+    );
+  });
+
+  describe('schema validation accepts valid IDs', () => {
+    it('RetrieveStyleSchema accepts valid alphanumeric styleId', () => {
+      expect(
+        RetrieveStyleSchema.safeParse({ styleId: VALID_STYLE_ID }).success
+      ).toBe(true);
+    });
+
+    it('DeleteStyleSchema accepts valid alphanumeric styleId', () => {
+      expect(
+        DeleteStyleSchema.safeParse({ styleId: VALID_STYLE_ID }).success
+      ).toBe(true);
+    });
+
+    it('UpdateStyleInputSchema accepts valid alphanumeric styleId', () => {
+      expect(
+        UpdateStyleInputSchema.safeParse({ styleId: VALID_STYLE_ID }).success
+      ).toBe(true);
+    });
+
+    it('PreviewStyleSchema accepts valid alphanumeric styleId', () => {
+      expect(
+        PreviewStyleSchema.safeParse({
+          styleId: VALID_STYLE_ID,
+          accessToken: PUBLIC_MOCK_TOKEN
+        }).success
+      ).toBe(true);
+    });
+
+    it.each([
+      'standard',
+      'standard-satellite',
+      'streets-v12',
+      'navigation-day-v1',
+      'dark-v11'
+    ])('RetrieveStyleSchema accepts built-in style name "%s"', (styleId) => {
+      expect(RetrieveStyleSchema.safeParse({ styleId }).success).toBe(true);
+    });
+
+    it('TilequerySchema accepts valid owner.tileset-name format', () => {
+      expect(
+        TilequerySchema.safeParse({
+          tilesetId: VALID_TILESET_ID,
+          longitude: 0,
+          latitude: 0
+        }).success
+      ).toBe(true);
+    });
+
+    it('TilequerySchema uses safe default when tilesetId is omitted', () => {
+      const result = TilequerySchema.safeParse({ longitude: 0, latitude: 0 });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tilesetId).toBe('mapbox.mapbox-streets-v8');
+      }
+    });
+  });
+
+  describe('URL path segments are encoded (defense-in-depth for username)', () => {
+    it('DeleteStyleTool encodes username containing "/" from JWT payload', async () => {
+      const maliciousToken = makeToken('user/attacker');
+      const { httpRequest, mockHttpRequest } = setupHttpRequest({
+        ok: true,
+        status: 204
+      });
+
+      await new DeleteStyleTool({ httpRequest }).run(
+        { styleId: VALID_STYLE_ID },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { authInfo: { token: maliciousToken } } as any
+      );
+
+      const calledUrl: string = mockHttpRequest.mock.calls[0][0];
+      expect(calledUrl).toContain('user%2Fattacker');
+      expect(calledUrl).not.toMatch(/\/styles\/v1\/user\/attacker\//);
+    });
+
+    it('PreviewStyleTool encodes username containing "/" in preview URL and resource URI', async () => {
+      const maliciousPublicToken = makePublicToken('user/attacker');
+
+      const result = await new PreviewStyleTool().run({
+        styleId: VALID_STYLE_ID,
+        accessToken: maliciousPublicToken
+      });
+
+      const url = result.content[0].text as string;
+      expect(url).toContain('user%2Fattacker');
+      expect(url).not.toMatch(/\/styles\/v1\/user\/attacker\//);
+    });
+
+    it('RetrieveStyleTool encodes username containing "/" from JWT payload', async () => {
+      const maliciousToken = makeToken('user/attacker');
+      const { httpRequest, mockHttpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => MOCK_STYLE_RESPONSE
+      });
+
+      await new RetrieveStyleTool({ httpRequest }).run(
+        { styleId: VALID_STYLE_ID },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { authInfo: { token: maliciousToken } } as any
+      );
+
+      const calledUrl: string = mockHttpRequest.mock.calls[0][0];
+      expect(calledUrl).toContain('user%2Fattacker');
+      expect(calledUrl).not.toMatch(/\/styles\/v1\/user\/attacker\//);
+    });
+
+    it('UpdateStyleTool encodes username containing "/" from JWT payload', async () => {
+      const maliciousToken = makeToken('user/attacker');
+      const { httpRequest, mockHttpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => MOCK_STYLE_RESPONSE
+      });
+
+      await new UpdateStyleTool({ httpRequest }).run(
+        { styleId: VALID_STYLE_ID },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { authInfo: { token: maliciousToken } } as any
+      );
+
+      const calledUrl: string = mockHttpRequest.mock.calls[0][0];
+      expect(calledUrl).toContain('user%2Fattacker');
+      expect(calledUrl).not.toMatch(/\/styles\/v1\/user\/attacker\//);
+    });
+  });
+
+  describe('response schema mismatch returns error instead of silently passing through', () => {
+    it('RetrieveStyleTool returns isError:true when API returns style array (traversal hit list endpoint)', async () => {
+      const { httpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => [MOCK_STYLE_RESPONSE, MOCK_STYLE_RESPONSE]
+      });
+
+      const result = await new RetrieveStyleTool({ httpRequest }).run({
+        styleId: VALID_STYLE_ID
+      });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('RetrieveStyleTool returns isError:true when API returns token list (traversal hit tokens endpoint)', async () => {
+      const { httpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => ({ tokens: ['tk.abc123', 'tk.def456'], count: 2 })
+      });
+
+      const result = await new RetrieveStyleTool({ httpRequest }).run({
+        styleId: VALID_STYLE_ID
+      });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('UpdateStyleTool returns isError:true when API returns wrong format', async () => {
+      const { httpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => ({ tokens: ['tk.abc123'], count: 1 })
+      });
+
+      const result = await new UpdateStyleTool({ httpRequest }).run({
+        styleId: VALID_STYLE_ID
+      });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('TilequeryTool returns isError:true when API returns non-FeatureCollection response', async () => {
+      const { httpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => ({ type: 'TokenList', tokens: ['tk.abc'] })
+      });
+
+      const result = await new TilequeryTool({ httpRequest }).run({
+        tilesetId: VALID_TILESET_ID,
+        longitude: 0,
+        latitude: 0
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/test/tools/create-token-tool/CreateTokenTool.test.ts
+++ b/test/tools/create-token-tool/CreateTokenTool.test.ts
@@ -44,8 +44,9 @@ describe('CreateTokenTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { CreateTokenSchema } =
-        await import('../../../src/tools/create-token-tool/CreateTokenTool.input.schema.js');
+      const { CreateTokenSchema } = await import(
+        '../../../src/tools/create-token-tool/CreateTokenTool.input.schema.js'
+      );
       expect(CreateTokenSchema).toBeDefined();
     });
   });
@@ -377,29 +378,15 @@ describe('CreateTokenTool', () => {
       } as Response);
 
       const tool = createTokenTool(httpRequest);
-      const logSpy = vi.spyOn(tool as any, 'log');
 
       const result = await tool.run({
         note: 'Test token',
         scopes: ['styles:read']
       });
 
-      // Should not error - graceful fallback to raw data
-      expect(result.isError).toBe(false);
+      // Schema validation failure now returns an error response
+      expect(result.isError).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
-
-      // Should log a warning about validation failure
-      expect(logSpy).toHaveBeenCalledWith(
-        'warning',
-        expect.stringContaining(
-          'CreateTokenTool: Output schema validation failed'
-        )
-      );
-
-      // Should return the raw data despite validation failure
-      const responseData = JSON.parse((result.content[0] as TextContent).text);
-      expect(responseData).toEqual(invalidMockResponse);
-      expect(responseData).toHaveProperty('unexpectedField');
     });
   });
 });

--- a/test/tools/create-token-tool/CreateTokenTool.test.ts
+++ b/test/tools/create-token-tool/CreateTokenTool.test.ts
@@ -44,9 +44,8 @@ describe('CreateTokenTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { CreateTokenSchema } = await import(
-        '../../../src/tools/create-token-tool/CreateTokenTool.input.schema.js'
-      );
+      const { CreateTokenSchema } =
+        await import('../../../src/tools/create-token-tool/CreateTokenTool.input.schema.js');
       expect(CreateTokenSchema).toBeDefined();
     });
   });

--- a/test/tools/create-token-tool/CreateTokenTool.test.ts
+++ b/test/tools/create-token-tool/CreateTokenTool.test.ts
@@ -386,6 +386,12 @@ describe('CreateTokenTool', () => {
       // Schema validation failure now returns an error response
       expect(result.isError).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
+      const errorText = (result.content[0] as { type: string; text: string })
+        .text;
+      expect(errorText).toMatch(
+        /Unexpected API response format from Mapbox API:/
+      );
+      expect(errorText).toContain('"code"');
     });
   });
 });

--- a/test/tools/delete-style-tool/DeleteStyleTool.test.ts
+++ b/test/tools/delete-style-tool/DeleteStyleTool.test.ts
@@ -29,9 +29,8 @@ describe('DeleteStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { DeleteStyleSchema } = await import(
-        '../../../src/tools/delete-style-tool/DeleteStyleTool.input.schema.js'
-      );
+      const { DeleteStyleSchema } =
+        await import('../../../src/tools/delete-style-tool/DeleteStyleTool.input.schema.js');
       expect(DeleteStyleSchema).toBeDefined();
     });
   });

--- a/test/tools/delete-style-tool/DeleteStyleTool.test.ts
+++ b/test/tools/delete-style-tool/DeleteStyleTool.test.ts
@@ -29,8 +29,9 @@ describe('DeleteStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { DeleteStyleSchema } =
-        await import('../../../src/tools/delete-style-tool/DeleteStyleTool.input.schema.js');
+      const { DeleteStyleSchema } = await import(
+        '../../../src/tools/delete-style-tool/DeleteStyleTool.input.schema.js'
+      );
       expect(DeleteStyleSchema).toBeDefined();
     });
   });
@@ -42,7 +43,7 @@ describe('DeleteStyleTool', () => {
     });
 
     const result = await new DeleteStyleTool({ httpRequest }).run({
-      styleId: 'style-123'
+      styleId: 'cmojrmkc9002t01ry96yi6h48'
     });
 
     expect(result.content[0]).toEqual({
@@ -60,7 +61,7 @@ describe('DeleteStyleTool', () => {
     });
 
     const result = await new DeleteStyleTool({ httpRequest }).run({
-      styleId: 'style-123'
+      styleId: 'cmojrmkc9002t01ry96yi6h48'
     });
     expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({

--- a/test/tools/list-styles-tool/ListStylesTool.test.ts
+++ b/test/tools/list-styles-tool/ListStylesTool.test.ts
@@ -30,8 +30,9 @@ describe('ListStylesTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { ListStylesSchema } =
-        await import('../../../src/tools/list-styles-tool/ListStylesTool.input.schema.js');
+      const { ListStylesSchema } = await import(
+        '../../../src/tools/list-styles-tool/ListStylesTool.input.schema.js'
+      );
       expect(ListStylesSchema).toBeDefined();
     });
   });
@@ -284,29 +285,12 @@ describe('ListStylesTool', () => {
     });
 
     const tool = new ListStylesTool({ httpRequest });
-    const logSpy = vi.spyOn(tool as any, 'log');
 
     const result = await tool.run({});
 
-    // Should not error - graceful fallback to raw data
-    expect(result.isError).toBe(false);
-    expect(result.content).toHaveLength(1);
+    // Schema validation failure now returns an error response
+    expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe('text');
-
-    // Should log a warning about validation failure
-    expect(logSpy).toHaveBeenCalledWith(
-      'warning',
-      expect.stringContaining('ListStylesTool: Output schema validation failed')
-    );
-
-    // Should return the raw data despite validation failure
-    const content = result.content[0];
-    if (content.type === 'text') {
-      const parsedResponse = JSON.parse(content.text);
-      expect(parsedResponse).toHaveProperty('styles');
-      expect(parsedResponse.styles).toEqual(invalidMockStyles);
-      expect(parsedResponse.styles[0]).toHaveProperty('customField');
-    }
 
     assertHeadersSent(mockHttpRequest);
   });

--- a/test/tools/list-styles-tool/ListStylesTool.test.ts
+++ b/test/tools/list-styles-tool/ListStylesTool.test.ts
@@ -30,9 +30,8 @@ describe('ListStylesTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { ListStylesSchema } = await import(
-        '../../../src/tools/list-styles-tool/ListStylesTool.input.schema.js'
-      );
+      const { ListStylesSchema } =
+        await import('../../../src/tools/list-styles-tool/ListStylesTool.input.schema.js');
       expect(ListStylesSchema).toBeDefined();
     });
   });

--- a/test/tools/list-styles-tool/ListStylesTool.test.ts
+++ b/test/tools/list-styles-tool/ListStylesTool.test.ts
@@ -290,6 +290,12 @@ describe('ListStylesTool', () => {
     // Schema validation failure now returns an error response
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe('text');
+    const errorText = (result.content[0] as { type: string; text: string })
+      .text;
+    expect(errorText).toMatch(
+      /Unexpected API response format from Mapbox API:/
+    );
+    expect(errorText).toContain('"code"');
 
     assertHeadersSent(mockHttpRequest);
   });

--- a/test/tools/list-tokens-tool/ListTokensTool.test.ts
+++ b/test/tools/list-tokens-tool/ListTokensTool.test.ts
@@ -43,8 +43,9 @@ describe('ListTokensTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { ListTokensSchema } =
-        await import('../../../src/tools/list-tokens-tool/ListTokensTool.input.schema.js');
+      const { ListTokensSchema } = await import(
+        '../../../src/tools/list-tokens-tool/ListTokensTool.input.schema.js'
+      );
       expect(ListTokensSchema).toBeDefined();
     });
   });
@@ -583,26 +584,12 @@ describe('ListTokensTool', () => {
       } as Response);
 
       const tool = createListTokensTool(httpRequest);
-      const logSpy = vi.spyOn(tool as any, 'log');
 
       const result = await tool.run({});
 
-      // Should not error - graceful fallback to raw data
-      expect(result.isError).toBe(false);
+      // Schema validation failure now returns an error response
+      expect(result.isError).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
-
-      // Should log a warning about validation failure
-      expect(logSpy).toHaveBeenCalledWith(
-        'warning',
-        expect.stringContaining(
-          'ListTokensTool: Output schema validation failed'
-        )
-      );
-
-      // Should return the raw data despite validation failure
-      const responseData = JSON.parse((result.content[0] as TextContent).text);
-      expect(responseData.tokens).toEqual(invalidMockTokens);
-      expect(responseData.tokens[0]).toHaveProperty('unexpectedField');
     });
   });
 });

--- a/test/tools/list-tokens-tool/ListTokensTool.test.ts
+++ b/test/tools/list-tokens-tool/ListTokensTool.test.ts
@@ -624,6 +624,12 @@ describe('ListTokensTool', () => {
       // Schema validation failure now returns an error response
       expect(result.isError).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
+      const errorText = (result.content[0] as { type: string; text: string })
+        .text;
+      expect(errorText).toMatch(
+        /Unexpected API response format from Mapbox API:/
+      );
+      expect(errorText).toContain('"code"');
     });
   });
 });

--- a/test/tools/list-tokens-tool/ListTokensTool.test.ts
+++ b/test/tools/list-tokens-tool/ListTokensTool.test.ts
@@ -427,6 +427,41 @@ describe('ListTokensTool', () => {
       expect(responseData.next_start).toBeUndefined();
     });
 
+    it('refuses cross-origin Link header to prevent token exfiltration', async () => {
+      const mockTokens = [
+        {
+          id: 'cktest123',
+          note: 'Token',
+          usage: 'pk',
+          client: 'api',
+          token: 'pk.eyJ1IjoidGVzdHVzZXIifQ.test123',
+          scopes: ['styles:read'],
+          created: '2023-01-01T00:00:00.000Z',
+          modified: '2023-01-01T00:00:00.000Z',
+          default: false
+        }
+      ];
+
+      const { httpRequest, mockHttpRequest } = setupHttpRequest();
+      const headers = new Headers();
+      headers.set('Link', '<https://attacker.example.com/collect>; rel="next"');
+
+      mockHttpRequest.mockResolvedValueOnce({
+        ok: true,
+        headers,
+        json: async () => mockTokens
+      } as Response);
+
+      const tool = createListTokensTool(httpRequest);
+      const result = await tool.run({});
+
+      expect(result.isError).toBe(false);
+      const responseData = JSON.parse((result.content[0] as TextContent).text);
+      expect(responseData.tokens).toHaveLength(1);
+      // Pagination should stop — no second request made to the attacker URL
+      expect(mockHttpRequest).toHaveBeenCalledTimes(1);
+    });
+
     it('filters by token usage type', async () => {
       const mockTokens = [
         {

--- a/test/tools/list-tokens-tool/ListTokensTool.test.ts
+++ b/test/tools/list-tokens-tool/ListTokensTool.test.ts
@@ -43,9 +43,8 @@ describe('ListTokensTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { ListTokensSchema } = await import(
-        '../../../src/tools/list-tokens-tool/ListTokensTool.input.schema.js'
-      );
+      const { ListTokensSchema } =
+        await import('../../../src/tools/list-tokens-tool/ListTokensTool.input.schema.js');
       expect(ListTokensSchema).toBeDefined();
     });
   });
@@ -59,7 +58,7 @@ describe('ListTokensTool', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
       const errorText = (result.content[0] as TextContent).text;
-      expect(errorText).toContain('<=100');
+      expect(errorText).toContain('too_big');
     });
 
     it('validates sortby enum values', async () => {

--- a/test/tools/preview-style-tool/PreviewStyleTool.test.ts
+++ b/test/tools/preview-style-tool/PreviewStyleTool.test.ts
@@ -21,15 +21,16 @@ describe('PreviewStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { PreviewStyleSchema } =
-        await import('../../../src/tools/preview-style-tool/PreviewStyleTool.input.schema.js');
+      const { PreviewStyleSchema } = await import(
+        '../../../src/tools/preview-style-tool/PreviewStyleTool.input.schema.js'
+      );
       expect(PreviewStyleSchema).toBeDefined();
     });
   });
 
   it('uses user-provided public token and returns preview URL', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       title: false,
       zoomwheel: false
@@ -39,14 +40,14 @@ describe('PreviewStyleTool', () => {
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: expect.stringContaining(
-        '/styles/v1/test-user/test-style.html?access_token=pk.'
+        '/styles/v1/test-user/cmojrmkc9002t01ry96yi6h48.html?access_token=pk.'
       )
     });
   });
 
   it('includes styleId in URL', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'my-custom-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h49',
       accessToken: TEST_ACCESS_TOKEN,
       title: false,
       zoomwheel: false
@@ -54,13 +55,15 @@ describe('PreviewStyleTool', () => {
 
     expect(result.content[0]).toMatchObject({
       type: 'text',
-      text: expect.stringContaining('/styles/v1/test-user/my-custom-style.html')
+      text: expect.stringContaining(
+        '/styles/v1/test-user/cmojrmkc9002t01ry96yi6h49.html'
+      )
     });
   });
 
   it('includes title parameter when provided', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       title: true,
       zoomwheel: false
@@ -74,7 +77,7 @@ describe('PreviewStyleTool', () => {
 
   it('includes zoomwheel parameter when provided', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       zoomwheel: false,
       title: false
@@ -88,7 +91,7 @@ describe('PreviewStyleTool', () => {
 
   it('includes fresh parameter for secure access', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       title: false,
       zoomwheel: false
@@ -102,7 +105,7 @@ describe('PreviewStyleTool', () => {
 
   it('rejects secret tokens', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken:
         'sk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIn0.secret_token',
       title: false,
@@ -120,7 +123,7 @@ describe('PreviewStyleTool', () => {
 
   it('rejects temporary tokens', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: 'tk.eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIn0.temp_token',
       title: false,
       zoomwheel: false
@@ -137,7 +140,7 @@ describe('PreviewStyleTool', () => {
 
   it('returns URL and MCP-UI resource on success (default)', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       title: false,
       zoomwheel: false
@@ -148,7 +151,7 @@ describe('PreviewStyleTool', () => {
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: expect.stringContaining(
-        'https://api.mapbox.com/styles/v1/test-user/test-style.html?access_token=pk.'
+        'https://api.mapbox.com/styles/v1/test-user/cmojrmkc9002t01ry96yi6h48.html?access_token=pk.'
       )
     });
 
@@ -163,9 +166,9 @@ describe('PreviewStyleTool', () => {
       type: 'resource',
       resource: {
         uri: expect.stringMatching(/^ui:\/\/mapbox\/preview-style\//),
-        mimeType: 'text/html;profile=mcp-app',
+        mimeType: 'text/uri-list',
         text: expect.stringContaining(
-          'https://api.mapbox.com/styles/v1/test-user/test-style.html?access_token=pk.'
+          'https://api.mapbox.com/styles/v1/test-user/cmojrmkc9002t01ry96yi6h48.html?access_token=pk.'
         )
       }
     });
@@ -173,7 +176,7 @@ describe('PreviewStyleTool', () => {
 
   it('returns URL and MCP-UI resource for backward compatibility', async () => {
     const result = await new PreviewStyleTool().run({
-      styleId: 'test-style',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       accessToken: TEST_ACCESS_TOKEN,
       title: false,
       zoomwheel: false
@@ -185,7 +188,7 @@ describe('PreviewStyleTool', () => {
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: expect.stringContaining(
-        'https://api.mapbox.com/styles/v1/test-user/test-style.html?access_token=pk.'
+        'https://api.mapbox.com/styles/v1/test-user/cmojrmkc9002t01ry96yi6h48.html?access_token=pk.'
       )
     });
     // Second item is MCP-UI resource

--- a/test/tools/preview-style-tool/PreviewStyleTool.test.ts
+++ b/test/tools/preview-style-tool/PreviewStyleTool.test.ts
@@ -21,9 +21,8 @@ describe('PreviewStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { PreviewStyleSchema } = await import(
-        '../../../src/tools/preview-style-tool/PreviewStyleTool.input.schema.js'
-      );
+      const { PreviewStyleSchema } =
+        await import('../../../src/tools/preview-style-tool/PreviewStyleTool.input.schema.js');
       expect(PreviewStyleSchema).toBeDefined();
     });
   });
@@ -166,7 +165,7 @@ describe('PreviewStyleTool', () => {
       type: 'resource',
       resource: {
         uri: expect.stringMatching(/^ui:\/\/mapbox\/preview-style\//),
-        mimeType: 'text/uri-list',
+        mimeType: 'text/html;profile=mcp-app',
         text: expect.stringContaining(
           'https://api.mapbox.com/styles/v1/test-user/cmojrmkc9002t01ry96yi6h48.html?access_token=pk.'
         )

--- a/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
+++ b/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
@@ -101,6 +101,22 @@ describe('RetrieveStyleTool', () => {
     assertHeadersSent(mockHttpRequest);
   });
 
+  it('returns error with validation details when API response does not match schema', async () => {
+    const { httpRequest } = setupHttpRequest({
+      ok: true,
+      json: async () => ({ unexpected: 'format' })
+    });
+
+    const result = await new RetrieveStyleTool({ httpRequest }).run({
+      styleId: 'cmojrmkc9002t01ry96yi6h48'
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: string; text: string }).text;
+    expect(text).toMatch(/Unexpected API response format from Mapbox API:/);
+    expect(text).toContain('"code"');
+  });
+
   it('handles styles with null terrain and other nullable fields', async () => {
     // Real-world API response with null values for optional fields
     const styleData = {

--- a/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
+++ b/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
@@ -29,14 +29,25 @@ describe('RetrieveStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { RetrieveStyleSchema } =
-        await import('../../../src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.js');
+      const { RetrieveStyleSchema } = await import(
+        '../../../src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.js'
+      );
       expect(RetrieveStyleSchema).toBeDefined();
     });
   });
 
   it('returns style data for successful fetch', async () => {
-    const styleData = { id: 'style-123', name: 'Test Style' };
+    const styleData = {
+      id: 'cmojrmkc9002t01ry96yi6h48',
+      name: 'Test Style',
+      owner: 'test-user',
+      version: 8,
+      created: '2020-01-01T00:00:00.000Z',
+      modified: '2020-01-01T00:00:00.000Z',
+      visibility: 'private' as const,
+      sources: {},
+      layers: []
+    };
     const { httpRequest, mockHttpRequest } = setupHttpRequest({
       ok: true,
       status: 200,
@@ -44,13 +55,21 @@ describe('RetrieveStyleTool', () => {
     });
 
     const result = await new RetrieveStyleTool({ httpRequest }).run({
-      styleId: 'style-123'
+      styleId: 'cmojrmkc9002t01ry96yi6h48'
     });
 
-    expect(result.content[0]).toMatchObject({
-      type: 'text',
-      text: JSON.stringify(styleData, null, 2)
-    });
+    expect(result.isError).toBe(false);
+    const content = result.content[0];
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      const parsed = JSON.parse(content.text);
+      expect(parsed).toMatchObject({
+        id: 'cmojrmkc9002t01ry96yi6h48',
+        name: 'Test Style',
+        owner: 'test-user',
+        version: 8
+      });
+    }
     assertHeadersSent(mockHttpRequest);
   });
 
@@ -64,7 +83,7 @@ describe('RetrieveStyleTool', () => {
     let result;
     try {
       result = await new RetrieveStyleTool({ httpRequest }).run({
-        styleId: 'style-456'
+        styleId: 'cmojrmkc9002t01ry96yi6h49'
       });
     } catch (e) {
       if (e instanceof Error) {
@@ -86,7 +105,7 @@ describe('RetrieveStyleTool', () => {
   it('handles styles with null terrain and other nullable fields', async () => {
     // Real-world API response with null values for optional fields
     const styleData = {
-      id: 'cjxyz123',
+      id: 'cmojrmkc9002t01ry96yi6h48',
       name: 'Production Style',
       owner: 'test-user',
       version: 8,
@@ -118,7 +137,7 @@ describe('RetrieveStyleTool', () => {
     });
 
     const result = await new RetrieveStyleTool({ httpRequest }).run({
-      styleId: 'cjxyz123'
+      styleId: 'cmojrmkc9002t01ry96yi6h48'
     });
 
     expect(result.isError).toBe(false);
@@ -130,7 +149,7 @@ describe('RetrieveStyleTool', () => {
       expect(parsedResponse.terrain).toBeNull();
       expect(parsedResponse.fog).toBeNull();
       expect(parsedResponse.lights).toBeNull();
-      expect(parsedResponse.id).toBe('cjxyz123');
+      expect(parsedResponse.id).toBe('cmojrmkc9002t01ry96yi6h48');
     }
 
     assertHeadersSent(mockHttpRequest);

--- a/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
+++ b/test/tools/retrieve-style-tool/RetrieveStyleTool.test.ts
@@ -29,9 +29,8 @@ describe('RetrieveStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { RetrieveStyleSchema } = await import(
-        '../../../src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.js'
-      );
+      const { RetrieveStyleSchema } =
+        await import('../../../src/tools/retrieve-style-tool/RetrieveStyleTool.input.schema.js');
       expect(RetrieveStyleSchema).toBeDefined();
     });
   });

--- a/test/tools/tilequery-tool/TilequeryTool.test.ts
+++ b/test/tools/tilequery-tool/TilequeryTool.test.ts
@@ -1,10 +1,15 @@
 // Copyright (c) Mapbox, Inc.
 // Licensed under the MIT License.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { TilequeryTool } from '../../../src/tools/tilequery-tool/TilequeryTool.js';
 import { TilequeryInput } from '../../../src/tools/tilequery-tool/TilequeryTool.input.schema.js';
 import { setupHttpRequest } from '../../utils/httpPipelineUtils.js';
+
+beforeAll(() => {
+  process.env.MAPBOX_ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoidGVzdC11c2VyIiwiYSI6InRlc3QtYXBpIn0.signature';
+});
 
 describe('TilequeryTool', () => {
   let tool: TilequeryTool;
@@ -97,6 +102,25 @@ describe('TilequeryTool', () => {
 
       const result = tool.inputSchema.safeParse(input);
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns error with validation details when API response does not match schema', async () => {
+      const { httpRequest } = setupHttpRequest({
+        ok: true,
+        json: async () => ({ unexpected: 'format' })
+      });
+
+      const result = await new TilequeryTool({ httpRequest }).run({
+        longitude: -122.4194,
+        latitude: 37.7749
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toMatch(/Unexpected API response format from Mapbox API:/);
+      expect(text).toContain('"code"');
     });
   });
 });

--- a/test/tools/update-style-tool/UpdateStyleTool.test.ts
+++ b/test/tools/update-style-tool/UpdateStyleTool.test.ts
@@ -29,8 +29,9 @@ describe('UpdateStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { UpdateStyleInputSchema } =
-        await import('../../../src/tools/update-style-tool/UpdateStyleTool.input.schema.js');
+      const { UpdateStyleInputSchema } = await import(
+        '../../../src/tools/update-style-tool/UpdateStyleTool.input.schema.js'
+      );
       expect(UpdateStyleInputSchema).toBeDefined();
     });
   });
@@ -38,11 +39,21 @@ describe('UpdateStyleTool', () => {
   it('sends custom header', async () => {
     const { httpRequest, mockHttpRequest } = setupHttpRequest({
       ok: true,
-      json: async () => ({ id: 'updated-style-id', name: 'Updated Style' })
+      json: async () => ({
+        id: 'cmojrmkc9002t01ry96yi6h48',
+        name: 'Updated Style',
+        owner: 'test-user',
+        version: 8,
+        created: '2020-01-01T00:00:00.000Z',
+        modified: '2020-01-01T00:00:00.000Z',
+        visibility: 'private',
+        sources: {},
+        layers: []
+      })
     });
 
     await new UpdateStyleTool({ httpRequest }).run({
-      styleId: 'style-123',
+      styleId: 'cmojrmkc9002t01ry96yi6h48',
       name: 'Updated Style',
       style: { version: 8, sources: {}, layers: [] }
     });
@@ -59,7 +70,7 @@ describe('UpdateStyleTool', () => {
     let result;
     try {
       result = await new UpdateStyleTool({ httpRequest }).run({
-        styleId: 'style-123',
+        styleId: 'cmojrmkc9002t01ry96yi6h48',
         name: 'Updated Style',
         style: { version: 8, sources: {}, layers: [] }
       });

--- a/test/tools/update-style-tool/UpdateStyleTool.test.ts
+++ b/test/tools/update-style-tool/UpdateStyleTool.test.ts
@@ -29,9 +29,8 @@ describe('UpdateStyleTool', () => {
     });
 
     it('should have correct input schema', async () => {
-      const { UpdateStyleInputSchema } = await import(
-        '../../../src/tools/update-style-tool/UpdateStyleTool.input.schema.js'
-      );
+      const { UpdateStyleInputSchema } =
+        await import('../../../src/tools/update-style-tool/UpdateStyleTool.input.schema.js');
       expect(UpdateStyleInputSchema).toBeDefined();
     });
   });


### PR DESCRIPTION
## Summary

Five MCP tools concatenated user-supplied path parameters directly into Mapbox API URLs without input validation or URL encoding. Because Node.js `fetch` uses the WHATWG URL parser, `../` sequences in a `styleId` or `tilesetId` input were normalized client-side before the request was sent — allowing the request to reach unintended API endpoints.

This PR applies a two-layer defense, hardens output schema validation across all affected tools, and adds two additional security fixes discovered during review.

## Changes

### Input validation — allowlist regex on all path parameters

- Add `src/tools/shared/styleId.schema.ts` — shared Zod schema with regex `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/`, which accepts both user-owned style IDs and built-in Mapbox style names (`standard`, `streets-v12`, `navigation-day-v1`, etc.) while rejecting path separators, dots, percent-encoded sequences, and null bytes
- Apply `styleIdSchema` to `DeleteStyleTool`, `PreviewStyleTool`, `RetrieveStyleTool`, and `UpdateStyleTool` input schemas via the shared module
- Add format validation to `TilequeryTool` `tilesetId` input: `/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/` (enforces `owner.tileset-name` format)

### URL encoding — `encodeURIComponent` at every construction site

Wrap both `username` (extracted from JWT) and `styleId`/`tilesetId` in `encodeURIComponent` at every URL construction site across all five tools. This encodes `/` → `%2F`, preventing any remaining path segments from being interpreted as directory traversal by the URL parser.

Affected files: `DeleteStyleTool.ts`, `PreviewStyleTool.ts` (URL + resource URI), `RetrieveStyleTool.ts`, `TilequeryTool.ts`, `UpdateStyleTool.ts`

### Output schema validation — hard-fail on mismatch

Replace the previous silent fallback behavior (returning raw unvalidated API responses) with explicit `isError: true` responses when the API response does not match the declared output schema. This prevents unintended API responses from being forwarded to callers.

Applied to: `RetrieveStyleTool`, `UpdateStyleTool`, `TilequeryTool`, `ListStylesTool`, `ListTokensTool`, `CreateTokenTool`

Remove now-unused `BaseTool.validateOutput()` method.

### Cross-origin Link header rejection (ListTokensTool)

`ListTokensTool` auto-paginates by following the `Link: rel=next` response header. Without origin validation, a malicious or compromised response could redirect pagination to an attacker-controlled host and exfiltrate the access token via the appended `access_token` query parameter.

Added origin validation: next-page URLs whose origin does not match the configured API endpoint are rejected with a warning log. Pagination stops rather than following a cross-origin redirect.

### Token redaction from logs and error messages

Added `redactToken()` utility that strips `access_token=...` query parameter values from strings before they reach log output or MCP client error responses. Network errors (DNS failure, timeout) from Node.js include the full request URL in their message — without redaction, the access token would be forwarded to callers in error responses.

Applied to: catch-block error messages in `MapboxApiBasedTool.run()`, debug-level URL log in `ListTokensTool`.

### Tests

- Add `test/security/path-traversal.test.ts` with **52 tests** covering schema rejection, valid ID acceptance, URL encoding, and response schema mismatch behavior
- Add cross-origin Link header rejection test in `ListTokensTool.test.ts`
- Fix test assertions for Prettier 3.8.x import formatting, Zod v4 error codes, and `@mcp-ui/server` v6.1.0 mimeType changes

## Test plan

- [x] `npm test` passes (576/576)
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run test/security/path-traversal.test.ts` — 52/52 pass
