### PR TITLE
docs: note that unsolicited directory/discovery listing PRs are out of scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Style ID validation for `style_comparison_tool`**: `before` and `after` inputs are now validated to contain only alphanumeric characters, hyphens, and underscores (after stripping the optional `mapbox://styles/` prefix). Validation is enforced at both the Zod schema layer and inside `processStyleId()`. Malformed style IDs are rejected with a descriptive error before any URL is constructed.
 
+### Documentation
+
+- **Engineering standards**: Note that unsolicited third-party directory/discovery listing PRs are out of scope and will be closed without review.
+
 ## 0.8.1 - 2026-06-11
 
 ### Changed

--- a/docs/engineering_standards.md
+++ b/docs/engineering_standards.md
@@ -97,6 +97,10 @@ Changes flow through pull requests requiring approval from core maintainers:
 - Run tests and linting before pushing: `npm test && npm run lint`
 - Build must succeed: `npm run build`
 
+**Out of Scope:**
+
+We do not accept PRs that add listings, badges, or manifest files for third-party directories, registries, or "discovery" services (e.g. unsolicited `README.md` badges linking to an external site, or manifest files with no functional purpose in this project). These will be closed without review.
+
 ## Security and DevOps
 
 **Environment Variables:**


### PR DESCRIPTION
## Summary
- Adds an "Out of Scope" note to docs/engineering_standards.md (Collaboration Workflow) stating that we don't accept PRs adding third-party directory/discovery listings (README badges, manifest files, etc.) with no functional value to the project. Existing legitimate listings (e.g. `glama.json`) are unaffected.
- Mirrors the same addition in [mapbox/mcp-server#226](https://github.com/mapbox/mcp-server/pull/226), prompted by a spam PR there adding a `beacon.json` manifest and README badge for an unverified third-party "agent discovery" site.

## Test plan
- [x] Docs-only change; no code paths affected
- [x] CHANGELOG.md updated per contributing guidelines