### PR TITLE
Bound input size in validate_expression_tool / validate_style_tool to prevent heap OOM

### DIFF
--- a/src/tools/validate-expression-tool/ValidateExpressionTool.input.schema.ts
+++ b/src/tools/validate-expression-tool/ValidateExpressionTool.input.schema.ts
@@ -3,9 +3,25 @@
 
 import { z } from 'zod';
 
+// Generous for any realistic hand-written or generated expression (even a
+// "match" with thousands of branches is a few KB), while bounding the size of
+// the JSON.parse'd/validated structure so a pathological payload can't be used
+// to exhaust memory before our own validation logic ever runs.
+const MAX_EXPRESSION_JSON_LENGTH = 262_144; // 256 KB
+
 export const ValidateExpressionInputSchema = z.object({
+  // `z.any()` in the union matches everything, including oversized strings, so
+  // `.max()` on the string branch alone would never trigger - the length check
+  // has to be a refinement applied after the union instead.
   expression: z
     .union([z.string(), z.any()])
+    .refine(
+      (value) =>
+        typeof value !== 'string' || value.length <= MAX_EXPRESSION_JSON_LENGTH,
+      {
+        message: `Expression JSON string exceeds maximum length of ${MAX_EXPRESSION_JSON_LENGTH} characters`
+      }
+    )
     .describe(
       'Mapbox expression to validate (JSON string or expression array)'
     ),

--- a/src/tools/validate-expression-tool/ValidateExpressionTool.ts
+++ b/src/tools/validate-expression-tool/ValidateExpressionTool.ts
@@ -29,6 +29,14 @@ const INTERPOLATION_TYPE_ARG_INDEX: Record<string, number> = {
 // This cap is far beyond any realistic hand-written or generated expression.
 const MAX_EXPRESSION_DEPTH = 64;
 
+// The depth cap alone doesn't bound memory: a single huge-but-shallow array
+// (e.g. a "match" with millions of branches) sails past it untouched, and
+// handing that straight to createPropertyExpression can exhaust the heap -
+// which, unlike a stack overflow, is not a catchable JS error and crashes the
+// whole process. Checking `.length` is O(1), so oversized arrays/objects are
+// rejected before we ever iterate into or copy them.
+const MAX_ARRAY_LENGTH = 10_000;
+
 // `StylePropertySpecification` only covers concrete typed properties (color, string,
 // number, ...), so a literal like `true` or `"red"` would fail type-checking against
 // any of them. Using an unrecognized `type` makes createPropertyExpression skip return
@@ -209,11 +217,28 @@ export class ValidateExpressionTool extends BaseTool<
 
     if (!Array.isArray(expression)) {
       if (typeof expression === 'object') {
+        if (Object.keys(expression).length > MAX_ARRAY_LENGTH) {
+          errors.push({
+            severity: 'error',
+            message: `Expression object exceeds maximum size of ${MAX_ARRAY_LENGTH} properties`,
+            path: path || 'root'
+          });
+          return { depth, blocking: true };
+        }
         return { expressionType: 'literal-object', depth, blocking: false };
       }
       errors.push({
         severity: 'error',
         message: 'Expression must be an array or literal value',
+        path: path || 'root'
+      });
+      return { depth, blocking: true };
+    }
+
+    if (expression.length > MAX_ARRAY_LENGTH) {
+      errors.push({
+        severity: 'error',
+        message: `Expression array exceeds maximum size of ${MAX_ARRAY_LENGTH} elements`,
         path: path || 'root'
       });
       return { depth, blocking: true };

--- a/src/tools/validate-style-tool/ValidateStyleTool.input.schema.ts
+++ b/src/tools/validate-style-tool/ValidateStyleTool.input.schema.ts
@@ -3,13 +3,24 @@
 
 import { z } from 'zod';
 
+// Generous for any real-world style (full styles with many layers/sources are
+// typically well under 1 MB), while bounding the size of the JSON.parse'd
+// structure so a pathological payload can't be used to exhaust memory before
+// our own validation logic ever runs. Unlike ValidateExpressionInputSchema,
+// `.max()` on the string branch alone is sufficient here since the object
+// branch (`z.record`) doesn't also match strings.
+const MAX_STYLE_JSON_LENGTH = 10 * 1024 * 1024; // 10 MB
+
 /**
  * Input schema for ValidateStyleTool
  * Validates Mapbox GL JS style JSON against the style specification
  */
 export const ValidateStyleInputSchema = z.object({
   style: z
-    .union([z.string(), z.record(z.string(), z.unknown())])
+    .union([
+      z.string().max(MAX_STYLE_JSON_LENGTH),
+      z.record(z.string(), z.unknown())
+    ])
     .describe(
       'Mapbox style JSON object or JSON string to validate against the Mapbox Style Specification'
     )

--- a/src/tools/validate-style-tool/ValidateStyleTool.ts
+++ b/src/tools/validate-style-tool/ValidateStyleTool.ts
@@ -47,19 +47,49 @@ function splitPathFromMessage(message: string): {
 // arbitrarily deep input without risking the same problem.
 const MAX_STYLE_DEPTH = 64;
 
-function exceedsMaxDepth(value: unknown, depth = 0): boolean {
+// Depth alone doesn't bound memory: a single huge-but-shallow array (e.g. a
+// paint expression's "match" with millions of branches) sails past the depth
+// cap untouched, and handing that straight to validateMapboxStyle can exhaust
+// the heap - which, unlike a stack overflow, is not a catchable JS error and
+// crashes the whole process. Checking `.length`/key count is O(1), so
+// oversized arrays/objects are rejected before we ever iterate into them.
+const MAX_STYLE_COLLECTION_SIZE = 10_000;
+
+type LimitViolation = 'depth' | 'size' | null;
+
+function findLimitViolation(value: unknown, depth = 0): LimitViolation {
   if (depth > MAX_STYLE_DEPTH) {
-    return true;
+    return 'depth';
   }
   if (Array.isArray(value)) {
-    return value.some((item) => exceedsMaxDepth(item, depth + 1));
+    if (value.length > MAX_STYLE_COLLECTION_SIZE) {
+      return 'size';
+    }
+    for (const item of value) {
+      const violation = findLimitViolation(item, depth + 1);
+      if (violation) {
+        return violation;
+      }
+    }
+    return null;
   }
   if (value && typeof value === 'object') {
-    return Object.values(value).some((item) =>
-      exceedsMaxDepth(item, depth + 1)
-    );
+    const keys = Object.keys(value);
+    if (keys.length > MAX_STYLE_COLLECTION_SIZE) {
+      return 'size';
+    }
+    for (const key of keys) {
+      const violation = findLimitViolation(
+        (value as Record<string, unknown>)[key],
+        depth + 1
+      );
+      if (violation) {
+        return violation;
+      }
+    }
+    return null;
   }
-  return false;
+  return null;
 }
 
 /**
@@ -128,14 +158,14 @@ export class ValidateStyleTool extends BaseTool<
         style = input.style as MapboxStyle;
       }
 
-      if (exceedsMaxDepth(style)) {
+      const limitViolation = findLimitViolation(style);
+      if (limitViolation) {
+        const message =
+          limitViolation === 'depth'
+            ? `style exceeds maximum nesting depth of ${MAX_STYLE_DEPTH}`
+            : `style contains an array or object exceeding maximum size of ${MAX_STYLE_COLLECTION_SIZE} elements`;
         return {
-          content: [
-            {
-              type: 'text',
-              text: `Error: style exceeds maximum nesting depth of ${MAX_STYLE_DEPTH}`
-            }
-          ],
+          content: [{ type: 'text', text: `Error: ${message}` }],
           isError: true
         };
       }

--- a/test/tools/validate-expression-tool/ValidateExpressionTool.test.ts
+++ b/test/tools/validate-expression-tool/ValidateExpressionTool.test.ts
@@ -339,6 +339,37 @@ describe('ValidateExpressionTool', () => {
         )
       ).toBe(true);
     });
+
+    it('should reject a wide (shallow but huge) expression instead of exhausting memory', async () => {
+      // Depth stays ~1 here - this is the vector the depth cap alone does not catch.
+      const expression: any = ['match', ['get', 'x']];
+      for (let i = 0; i < 20_000; i++) {
+        expression.push(i, 'red');
+      }
+      expression.push('blue');
+
+      const start = Date.now();
+      const result = await tool.run({ expression });
+      expect(Date.now() - start).toBeLessThan(1000);
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.valid).toBe(false);
+      expect(
+        parsed.errors.some((e: any) =>
+          e.message.includes('exceeds maximum size')
+        )
+      ).toBe(true);
+    });
+
+    it('should reject a JSON string expression exceeding the maximum length', async () => {
+      const expression = JSON.stringify(['get', 'x'.repeat(300_000)]);
+
+      const result = await tool.run({ expression });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('exceeds maximum length');
+    });
   });
 
   describe('nested expressions', () => {

--- a/test/tools/validate-style-tool/ValidateStyleTool.test.ts
+++ b/test/tools/validate-style-tool/ValidateStyleTool.test.ts
@@ -357,5 +357,45 @@ describe('ValidateStyleTool', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('exceeds maximum nesting depth');
     });
+
+    it('should reject a style with a wide (shallow but huge) expression instead of exhausting memory', async () => {
+      // Depth stays ~1 here - this is the vector the depth cap alone does not catch.
+      const expression: any = ['match', ['get', 'x']];
+      for (let i = 0; i < 20_000; i++) {
+        expression.push(i, 'red');
+      }
+      expression.push('blue');
+      const style = {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: 'l',
+            type: 'background',
+            paint: { 'background-opacity': expression }
+          }
+        ]
+      };
+
+      const start = Date.now();
+      const result = await tool.run({ style });
+      expect(Date.now() - start).toBeLessThan(1000);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('exceeding maximum size');
+    });
+
+    it('should reject a JSON string style exceeding the maximum length', async () => {
+      const style = JSON.stringify({
+        version: 8,
+        sources: {},
+        layers: [],
+        padding: 'x'.repeat(11 * 1024 * 1024)
+      });
+
+      const result = await tool.run({ style });
+
+      expect(result.isError).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #125, addressing [review feedback from @Valiunia](https://github.com/mapbox/mcp-devkit-server/pull/125#discussion_r3578466753) about unbounded recursion in the new style-spec-delegating validators.

The depth cap added in #125 only protects against *deep* adversarial input (a long linear chain). It does not protect against *wide*-but-shallow input - e.g. a single `match` expression with millions of branches, at depth ~1 - which sails past the cap untouched and gets handed whole to `createPropertyExpression`/`validate()`.

|  | Deep (stack overflow) | Wide (heap OOM) |
|---|---|---|
| Triggered by | linear nesting depth | total array/object size |
| Caught by our `try/catch`? | **Yes** - `RangeError` is a normal JS exception | **No** - V8 aborts the process before JS code can run |
| Blast radius | that one request fails | **entire process dies**, killing every concurrent MCP session |
| Stopped by the #125 depth-64 cap? | Yes | **No** - depth never exceeds ~1 |
| Stopped by this PR? | Yes (already, via #125) | **Yes** |

Reproduced the wide case under a memory-constrained process (`node --max-old-space-size=150`) and confirmed it's worse than the stack-overflow case: heap exhaustion is **not** a catchable JS exception - V8 aborts the process directly (`FATAL ERROR: Reached heap limit`, `SIGABRT`), which would take down every concurrent MCP session, not just the one request.

Fixed with two layers of defense:
- **Schema-level size caps** on the JSON-string form of `expression` (256 KB) and `style` (10 MB) in their Zod schemas, rejected before `JSON.parse` ever runs. Note: for `validate_expression_tool`, `z.union([z.string().max(N), z.any()])` does **not** work, since the sibling `z.any()` branch matches everything, including oversized strings, and swallows them right past the length check - had to use a `.refine()` instead.
- **O(1) array-length / object-key-count guard**, checked via `.length` before ever iterating into or copying the collection, alongside the existing depth guard. This covers the already-parsed object-input path too (not just JSON strings), and rejects an oversized array/object anywhere in the tree without visiting its elements.

## Test plan

- [x] `npm test` - all 596 tests pass, including new regression tests for both the wide-payload and oversized-string cases in both tools (asserting fast rejection, not just non-crash)
- [x] `npm run lint` - 0 errors
- [x] `npm run build` - succeeds
- [x] Manually reproduced the OOM crash pre-fix (`node --max-old-space-size=150` + a 2,000,000-branch `match` expression → `SIGABRT`/`FATAL ERROR: Reached heap limit`) and confirmed post-fix it's rejected in ~1ms with a clear error instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
