### PR TITLE
chore: bump @modelcontextprotocol/sdk to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Dependencies
+
+- Bumped `@modelcontextprotocol/sdk` to `1.30.0`. Not adopting the `2026-07-28` spec revision this release covers (stateless request/response model, elicitation replaced by Multi Round-Trip Requests, Sampling deprecated) — that's a separate migration, tracked in #130, given this repo's own elicitation-based features depend on the mechanism being replaced. Regenerated `patches/@modelcontextprotocol+sdk+1.30.0.patch` (previously pinned to `1.29.0`) — same patch content, applies cleanly to the new version, verified live against the built server.
+
 ## 0.8.2 - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/mapbox-gl-style-spec": "^14.26.0",
         "@mcp-ui/server": "^6.1.0",
         "@modelcontextprotocol/ext-apps": "^1.1.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.74.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
@@ -1643,12 +1643,12 @@
       ]
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mapbox/mapbox-gl-style-spec": "^14.26.0",
     "@mcp-ui/server": "^6.1.0",
     "@modelcontextprotocol/ext-apps": "^1.1.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.74.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",

--- a/patches/@modelcontextprotocol+sdk+1.30.0.patch
+++ b/patches/@modelcontextprotocol+sdk+1.30.0.patch
@@ -1,6 +1,8 @@
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
+index 9e1c874..781ebad 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
-@@ -197,7 +197,7 @@
+@@ -197,7 +197,7 @@ class McpServer {
              return;
          }
          if (!result.structuredContent) {
@@ -9,7 +11,7 @@
          }
          // if the tool has an output schema, validate structured content
          const outputObj = (0, zod_compat_js_1.normalizeObjectSchema)(tool.outputSchema);
-@@ -205,7 +205,7 @@
+@@ -205,7 +205,7 @@ class McpServer {
          if (!parseResult.success) {
              const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
              const errorMessage = (0, zod_compat_js_1.getParseErrorMessage)(error);
@@ -18,9 +20,11 @@
          }
      }
      /**
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+index 2314d88..94aaef1 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
-@@ -194,15 +194,20 @@
+@@ -194,15 +194,20 @@ export class McpServer {
              return;
          }
          if (!result.structuredContent) {


### PR DESCRIPTION
## What changed

Bumps `@modelcontextprotocol/sdk` from `1.29.0` to `1.30.0` — within the existing `^1.29.0` range, so this is really just catching the lockfile up. Also regenerates `patches/@modelcontextprotocol+sdk+1.30.0.patch` (previously pinned to `1.29.0` in its filename); the patch content is unchanged, just re-based against the new version.

## Not in scope here

This does **not** adopt the `2026-07-28` MCP spec revision this SDK version also supports (stateless request/response model, elicitation replaced by Multi Round-Trip Requests, Sampling deprecated). That's a real migration, not a version bump — this repo's own in-progress elicitation work (PR #57) depends on the exact mechanism being replaced. Tracked separately in #130.

## Verification

- This repo patches `@modelcontextprotocol/sdk`'s `mcp.js` (converts SDK-level output-validation throws into warnings), so the real risk here wasn't the version bump itself, it was whether the patch still applies. Ran `npx patch-package` explicitly after the bump (not just relying on `postinstall`, which swallows failures via `|| true`) — it applied cleanly with only a filename-version-mismatch warning, and confirmed the patched (`console.warn`, not `throw`) code is actually present in the installed `dist/cjs` and `dist/esm` files.
- `npx eslint`: 0 errors.
- Full suite: 611/611 pass.
- `npm run build` succeeds.
- Live-tested the actual built server via a real MCP stdio client: connects, `bounding_box_tool` call succeeds end-to-end.

Note: this was built in an isolated `git worktree` rather than the primary checkout, since another branch (`add-preview-token-elicitation`) was actively checked out there mid-task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)