### PR TITLE
chore: bump @modelcontextprotocol/sdk to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Dependencies
+
+- Bumped `@modelcontextprotocol/sdk` to `1.30.0`. Not adopting the `2026-07-28` spec revision this release covers (stateless request/response model, elicitation replaced by Multi Round-Trip Requests, Sampling deprecated) — that's a separate migration, tracked in #130, given this repo's own elicitation-based features depend on the mechanism being replaced. Regenerated `patches/@modelcontextprotocol+sdk+1.30.0.patch` (previously pinned to `1.29.0`) — same patch content, applies cleanly to the new version, verified live against the built server.
+
 ## 0.8.2 - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/mapbox-gl-style-spec": "^14.26.0",
         "@mcp-ui/server": "^6.1.0",
         "@modelcontextprotocol/ext-apps": "^1.1.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.74.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
@@ -1643,12 +1643,12 @@
       ]
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mapbox/mapbox-gl-style-spec": "^14.26.0",
     "@mcp-ui/server": "^6.1.0",
     "@modelcontextprotocol/ext-apps": "^1.1.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.74.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",

--- a/patches/@modelcontextprotocol+sdk+1.30.0.patch
+++ b/patches/@modelcontextprotocol+sdk+1.30.0.patch
@@ -1,6 +1,8 @@
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
+index 9e1c874..781ebad 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
-@@ -197,7 +197,7 @@
+@@ -197,7 +197,7 @@ class McpServer {
              return;
          }
          if (!result.structuredContent) {
@@ -9,7 +11,7 @@
          }
          // if the tool has an output schema, validate structured content
          const outputObj = (0, zod_compat_js_1.normalizeObjectSchema)(tool.outputSchema);
-@@ -205,7 +205,7 @@
+@@ -205,7 +205,7 @@ class McpServer {
          if (!parseResult.success) {
              const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
              const errorMessage = (0, zod_compat_js_1.getParseErrorMessage)(error);
@@ -18,9 +20,11 @@
          }
      }
      /**
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+index 2314d88..94aaef1 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
-@@ -194,15 +194,20 @@
+@@ -194,15 +194,20 @@ export class McpServer {
              return;
          }
          if (!result.structuredContent) {


### PR DESCRIPTION
Patch/minor bump within the existing ^1.29.0 range. Does not adopt the 2026-07-28 spec revision this SDK version supports (stateless model, elicitation -> MRTR, Sampling deprecated) - that's a separate migration, tracked in #130, given this repo's own in-progress elicitation work (PR #57) depends on the mechanism being replaced.

Regenerated patches/@modelcontextprotocol+sdk+1.30.0.patch (same content, just re-based off the new version) after verifying it still applies cleanly and the patched (warn-not-throw) behavior is present in the installed dist files.

## Description

<!-- Provide a clear explanation of what has been implemented or fixed. Mention any related context, requirements, or issues. -->

- Closes #[issue-number] (if applicable)

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
